### PR TITLE
security: update 

### DIFF
--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -73,7 +73,7 @@ sidecar>=0.5.0
 ipywidgets>=8.0.0
 ipython>=8.0.0
 imagesize==1.4.1
-setuptools==78.1.0
+setuptools==78.1.1
 
 # -- Monitoring & Logging --
 tensorboard==2.16.2


### PR DESCRIPTION
Security update setuptools to 78.1.1 to fix CVE path traversal vulnerability

- Bumped setuptools from 78.1.0 to 78.1.1
- Fixes path traversal vulnerability in PackageIndex (GHSA-r9hx-vwmv-q579)
- See: https://github.com/pypa/setuptools/security/advisories/GHSA-r9hx-vwmv-q579