### PR TITLE
ci: Add Docker build workflow for VastAI deployment

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,48 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'  # Triggers on any tag starting with 'v' (v0.1-dev, v0.2-alpha, v1.0.0, etc.)
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # Required to push to ghcr.io
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/ktiseos-nyx/ktiseos-nyx-trainer
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.vastai
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow for automated Docker image builds triggered by version tags.

## What's New

**Docker Build Workflow** (`.github/workflows/docker-build.yml`)
- Builds Docker images from `Dockerfile.vastai`
- Pushes to GitHub Container Registry (ghcr.io)
- Triggered by version tags (v0.1-dev, v0.2-alpha, v1.0.0, etc.)
- Builds for `linux/amd64` platform (VastAI compatible)

## Features

✅ **No rate limits** - Uses ghcr.io instead of Docker Hub  
✅ **Tag-based releases** - Only builds when you create a version tag  
✅ **VastAI optimized** - Uses Dockerfile.vastai with VastAI base image  
✅ **Automatic tagging** - Tags images with version + "latest"  
✅ **Build caching** - GitHub Actions cache for faster builds  

## How to Use

**Create a release:**
```bash
git tag v0.1-dev
git push origin v0.1-dev
```

**Image will be available at:**
- `ghcr.io/ktiseos-nyx/ktiseos-nyx-trainer:v0.1-dev`
- `ghcr.io/ktiseos-nyx/ktiseos-nyx-trainer:latest`

**Deploy to VastAI:**
```bash
docker pull ghcr.io/ktiseos-nyx/ktiseos-nyx-trainer:v0.1-dev
```

## Testing Plan

- [ ] Test workflow by creating a test tag (v0.1-dev)
- [ ] Verify image builds successfully on GitHub Actions
- [ ] Verify image appears in ghcr.io
- [ ] Pull image on VastAI and test deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)