### PR TITLE
fix: Remove reference to non-existent shared_managers.py 

### DIFF
--- a/Dockerfile.vastai
+++ b/Dockerfile.vastai
@@ -54,7 +54,6 @@ RUN uv pip install --system -r /tmp/requirements-backend.txt \
 COPY api/ /opt/workspace-internal/Ktiseos-Nyx-Trainer/api/
 COPY core/ /opt/workspace-internal/Ktiseos-Nyx-Trainer/core/
 COPY widgets/ /opt/workspace-internal/Ktiseos-Nyx-Trainer/widgets/
-COPY shared_managers.py /opt/workspace-internal/Ktiseos-Nyx-Trainer/
 COPY installer.py /opt/workspace-internal/Ktiseos-Nyx-Trainer/
 
 # Copy frontend code for building


### PR DESCRIPTION
from Dockerfile.vastai

The shared_managers.py file doesn't exist in the repo and was causing Docker build failures. Removed the COPY command for this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)