### PR TITLE
Fix: Modernize VastAI template scripts for vendored backend

### DIFF
--- a/start_services_vastai.sh
+++ b/start_services_vastai.sh
@@ -41,7 +41,14 @@ if [ -d "frontend" ]; then
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
     cd frontend
-    npm start -- -p 3000 &
+
+    # Check if build exists
+    if [ ! -d ".next" ]; then
+        echo "   ⚠️  No build found, running npm run build first..."
+        npm run build
+    fi
+
+    npm run start &
     FRONTEND_PID=$!
     echo "   Frontend PID: $FRONTEND_PID"
     cd ..

--- a/template.json
+++ b/template.json
@@ -1,7 +1,7 @@
 {
   "name": "Ktiseos Nyx LoRA Trainer",
-  "version": "0.9.0-beta",
-  "description": "⚠️ BETA: In active development - may not work as expected. Professional LoRA training environment for SDXL, SD 1.5, Flux, and SD3. Features a modern Next.js web UI with comprehensive training configuration, real-time monitoring, dataset management, and automatic captioning. Powered by Kohya's sd-scripts with LyCORIS support.",
+  "version": "0.9.1-beta",
+  "description": "⚠️ BETA: In active development - may not work as expected. Professional LoRA training environment for SDXL, SD 1.5, Flux, and SD3. Features a modern Next.js web UI with comprehensive training configuration, real-time monitoring, dataset management, and automatic captioning. Powered by Kohya's sd-scripts with LyCORIS support. Uses vendored backend for reliable deployment.",
   "author": "Duskfall",
   "tags": [
     "stable-diffusion",
@@ -16,14 +16,18 @@
     "lycoris"
   ],
   "image": {
-    "dockerfile": "Dockerfile",
+    "dockerfile": "Dockerfile.vastai",
     "build_context": ".",
-    "base_image": "nvidia/cuda:12.1.0-cudnn8-devel-ubuntu22.04"
+    "base_image": "vastai/pytorch:2.6.0-cuda-12.6.3-py312"
   },
   "launch_mode": {
     "default": "jupyter_ssh",
     "supported": ["jupyter_ssh", "ssh", "docker_entrypoint"],
     "description": "Jupyter+SSH mode recommended for debugging and manual intervention if services fail"
+  },
+  "provisioning": {
+    "script_url": "https://raw.githubusercontent.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/main/vastai_setup.sh",
+    "description": "Automatic setup script that clones repo, installs dependencies, builds frontend, and starts services"
   },
   "gpu": {
     "required": true,

--- a/vastai_setup.sh
+++ b/vastai_setup.sh
@@ -18,56 +18,35 @@ cd /workspace
 # Clone the repository if it doesn't exist
 if [ ! -d "Ktiseos-Nyx-Trainer" ]; then
     echo "📥 Cloning repository..."
-    git clone --recursive https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer.git
+    git clone https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer.git
 else
     echo "📂 Repository already exists, pulling latest changes..."
     cd Ktiseos-Nyx-Trainer
     git pull
-    git submodule update --init --recursive
     cd ..
 fi
 
 cd Ktiseos-Nyx-Trainer
 
-# Install Python dependencies (backend)
-echo "🐍 Installing backend dependencies..."
-pip install --upgrade pip
-if [ -f "requirements-backend.txt" ]; then
-    pip install -r requirements-backend.txt
-fi
-
-# Install Python dependencies (API)
-echo "🔌 Installing API dependencies..."
-if [ -f "requirements-api.txt" ]; then
-    pip install -r requirements-api.txt
-fi
-
-# Setup Derrian Backend with SD-Scripts (submodule)
-echo "🔧 Setting up Derrian Backend & SD-Scripts..."
-if [ -d "trainer/derrian_backend" ]; then
-    cd trainer/derrian_backend
-
-    # Run backend installer with piped answers (non-interactive)
-    # Question 1: "are you using this remotely?" -> y (VastAI is remote)
-    # Question 2: "do you want to use ngrok?" -> n (we use VastAI port forwarding)
-    if [ -f "installer.py" ]; then
-        echo "   Running Derrian backend installer (non-interactive)..."
-        echo -e "y\nn" | python installer.py
-    fi
-
-    # Install sd-scripts dependencies
-    if [ -d "sd_scripts" ]; then
-        cd sd_scripts
-        if [ -f "requirements.txt" ]; then
-            echo "   Installing sd-scripts requirements..."
-            pip install -r requirements.txt
-        fi
-        cd ..
-    fi
-
-    cd ../..
+# Run unified installer (handles all backend dependencies and setup)
+echo "🔧 Running unified installer..."
+if [ -f "installer.py" ]; then
+    python installer.py
 else
-    echo "⚠️  Derrian backend not found - skipping sd-scripts setup"
+    echo "⚠️  installer.py not found - falling back to manual dependency installation"
+
+    # Fallback: Install dependencies manually
+    echo "🐍 Installing backend dependencies..."
+    pip install --upgrade pip
+    if [ -f "requirements-backend.txt" ]; then
+        pip install -r requirements-backend.txt
+    fi
+
+    # Install API dependencies
+    echo "🔌 Installing API dependencies..."
+    if [ -f "requirements-api.txt" ]; then
+        pip install -r requirements-api.txt
+    fi
 fi
 
 # Setup Next.js Frontend
@@ -93,8 +72,8 @@ else
 fi
 
 # Make startup script executable
-if [ -f "start_services.sh" ]; then
-    chmod +x start_services.sh
+if [ -f "start_services_vastai.sh" ]; then
+    chmod +x start_services_vastai.sh
 fi
 
 echo ""
@@ -106,11 +85,11 @@ echo "🚀 Starting services..."
 echo ""
 
 # Start the services
-if [ -f "start_services.sh" ]; then
-    ./start_services.sh
+if [ -f "start_services_vastai.sh" ]; then
+    ./start_services_vastai.sh
 else
-    echo "⚠️  start_services.sh not found"
+    echo "⚠️  start_services_vastai.sh not found"
     echo "   Manually start services with:"
-    echo "   - Backend: python -m uvicorn api.main:app --host 0.0.0.0 --port 8000"
-    echo "   - Frontend: cd frontend && npm start -- -p 3000"
+    echo "   - Backend: uvicorn api.main:app --host 0.0.0.0 --port 8000"
+    echo "   - Frontend: cd frontend && npm run start"
 fi


### PR DESCRIPTION
## Summary
- Fixed VastAI template scripts to work with vendored backend architecture
- Removed outdated submodule commands
- Fixed npm start command for Next.js
- Updated template.json references

## Problem
VastAI template scripts were from the submodule era and broke after vendoring refactor:
- Tried to run `git clone --recursive` (no more submodules)
- Tried to run `trainer/derrian_backend/installer.py` (doesn't exist)
- Used wrong npm command `npm start -- -p 3000`
- Services never started → Caddy showed "waiting" forever

## Changes

### vastai_setup.sh
- Removed `--recursive` and submodule update commands
- Now runs unified `installer.py` from project root
- References correct `start_services_vastai.sh` script
- Removed redundant sd-scripts dependency install

### start_services_vastai.sh
- Fixed: `npm start -- -p 3000` → `npm run start`
- Added build check for `.next` directory
- Proper Next.js production start command

### template.json
- Updated to v0.9.1-beta
- Dockerfile reference: `Dockerfile` → `Dockerfile.vastai`
- Base image updated to match actual Dockerfile
- Added provisioning script URL

## Testing
Ready to test with VastAI PyTorch template + provisioning script URL

## Alternative to Docker
This provides a working VastAI deployment without needing the 30GB Docker image that broke GitHub Actions!

🤖 Generated with [Claude Code](https://claude.com/claude-code)