### PR TITLE
Fix: Match supervisor script search term to portal config

### DIFF
--- a/vastai_setup.sh
+++ b/vastai_setup.sh
@@ -206,7 +206,7 @@ while [ ! -f "$(realpath -q /etc/portal.yaml 2>/dev/null)" ]; do
 done
 
 # Check for our services in the portal config
-search_term="NextJS Frontend"
+search_term="Frontend"
 search_pattern=$(echo "$search_term" | sed 's/[ _-]/[ _-]/g')
 if ! grep -qiE "^[^#].*${search_pattern}" /etc/portal.yaml; then
     echo "Skipping startup for ${PROC_NAME} (not in /etc/portal.yaml)" | tee -a "/var/log/portal/${PROC_NAME}.log"


### PR DESCRIPTION
Changed search term from 'NextJS Frontend' to 'Frontend' to match the service name in PORTAL_CONFIG from Docker Options.

This fixes the 'not in /etc/portal.yaml' skip condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)