### PR TITLE
Chore: Fixing binding in the nextJS package json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "next dev -H localhost",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -H 0.0.0.0",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
What claude found out:

Ah! Next.js is binding to localhost instead of 0.0.0.0!

  The frontend IS running (you can see it in the logs), but it's only listening on localhost, not on all network interfaces. That's why lsof -i :3000 shows nothing.

  Look at this:
  - Local:        http://localhost:3000
  - Network:      http://172.17.0.2:3000  ← Docker internal IP

  We need to tell Next.js to bind to 0.0.0.0 so it's accessible externally. Let me check and fix the startup command:

⏺ Read(frontend/package.json)
  ⎿  Read 93 lines

⏺ Found it! Line 11 - the start script doesn't specify the hostname. Let me fix it:

⏺ Update(frontend/package.json)
  ⎿  Updated frontend/package.json with 1 addition and 1 removal
        8      "scripts": {
        9        "dev": "next dev -H localhost",
       10        "build": "next build",
       11 -      "start": "next start",
       11 +      "start": "next start -H 0.0.0.0",
       12        "lint": "next lint"
       13      },
       14      "dependencies": {

⏺ Perfect! Now Next.js will bind to 0.0.0.0:3000 instead of localhost:3000.