### PR TITLE
fix: Critical installer and startup script bug fixes (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,7 @@ LoRA training system built on Kohya SS with a modern web UI (Next.js + FastAPI).
 git clone https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer.git
 cd Ktiseos-Nyx-Trainer
 
-REM Create virtual environment
-python -m venv venv
-
-REM Activate it (you'll do this EVERY TIME you open a new terminal)
-venv\Scripts\activate
-
-REM Now install - packages stay in the venv
+REM The installer will ask if you want a venv (say yes!)
 install.bat
 ```
 
@@ -43,28 +37,18 @@ install.bat
 git clone https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer.git
 cd Ktiseos-Nyx-Trainer
 
-# Create virtual environment
-python3 -m venv venv
-
-# Activate it (you'll do this EVERY TIME you open a new terminal)
-source venv/bin/activate
-
-# Now install - packages stay in the venv
-python installer_local_linux.py
+# The installer will ask if you want a venv (say yes!)
+./install.sh
 ```
 
-**Starting the app with venv:**
+**Starting the app:**
 ```bash
-# Activate venv first
-venv\Scripts\activate   # Windows
-source venv/bin/activate  # Linux
-
-# Then start services
+# The start scripts automatically activate your venv if it exists!
 start_services_local.bat  # Windows
 ./start_services_local.sh # Linux
 ```
 
-> 💡 **Pro tip:** Your terminal prompt will show `(venv)` when the virtual environment is active. If you don't see it, activate again!
+> 💡 **Pro tip:** The start scripts now handle venv activation automatically. Just run them and go!
 
 ---
 
@@ -74,7 +58,7 @@ start_services_local.bat  # Windows
 ```bat
 git clone https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer.git
 cd Ktiseos-Nyx-Trainer
-install.bat
+install.bat --no-venv
 start_services_local.bat
 ```
 
@@ -82,7 +66,7 @@ start_services_local.bat
 ```bash
 git clone https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer.git
 cd Ktiseos-Nyx-Trainer
-python installer_local_linux.py
+./install.sh --no-venv
 ./start_services_local.sh
 ```
 

--- a/install.bat
+++ b/install.bat
@@ -8,7 +8,7 @@ REM ======================================================================
 
 set PYTHONIOENCODING=utf-8
 set USE_VENV=
-set VENV_DIR=venv
+set VENV_DIR=.venv
 set AUTO_MODE=0
 
 REM Parse command-line arguments
@@ -51,7 +51,7 @@ if not defined USE_VENV (
     echo.
     echo Benefits:
     echo   - No conflicts with other Python projects
-    echo   - Easy to delete if you want to start fresh (just delete 'venv' folder^)
+    echo   - Easy to delete if you want to start fresh (just delete '.venv' folder^)
     echo   - Industry best practice for Python development
     echo.
     echo The venv will be created in: %CD%\%VENV_DIR%
@@ -76,7 +76,7 @@ REM Create venv if requested
 if "%USE_VENV%"=="1" (
     if not exist "%VENV_DIR%\Scripts\activate.bat" (
         echo Creating virtual environment in '%VENV_DIR%'...
-        py -3.10 -m venv %VENV_DIR%
+        py -3 -m venv "%VENV_DIR%"
         if errorlevel 1 (
             echo.
             echo ERROR: Failed to create virtual environment.
@@ -92,7 +92,7 @@ if "%USE_VENV%"=="1" (
     )
 
     echo Activating virtual environment...
-    call %VENV_DIR%\Scripts\activate.bat
+    call "%VENV_DIR%\Scripts\activate.bat"
     echo.
     echo ^(venv^) Virtual environment activated.
     echo Python: %VENV_DIR%\Scripts\python.exe
@@ -101,15 +101,15 @@ if "%USE_VENV%"=="1" (
     echo.
 
     REM Run installer with venv Python, passing through remaining args
-    %VENV_DIR%\Scripts\python.exe installer_windows_local.py %*
+    "%VENV_DIR%\Scripts\python.exe" installer_windows_local.py %*
 ) else (
     echo Running installer WITHOUT virtual environment...
     echo.
     echo Checking Python installation...
     echo.
 
-    REM Use py.exe launcher to find Python 3.10+
-    py -3.10 installer_windows_local.py %*
+    REM Use py.exe launcher to find latest Python 3.x
+    py -3 installer_windows_local.py %*
 )
 
 REM Check the exit code from the Python script

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ cd "$SCRIPT_DIR"
 # --- Configuration ---
 PYTHON_CMD="python3"
 MIN_PYTHON_VERSION="3.10"
-VENV_DIR="venv"
+VENV_DIR=".venv"
 INSTALLER_PY="install_linux.py"
 USE_VENV=""
 AUTO_MODE=0
@@ -80,7 +80,7 @@ if [ -z "$USE_VENV" ]; then
     echo ""
     echo "Benefits:"
     echo "  - No conflicts with other Python projects"
-    echo "  - Easy to delete if you want to start fresh (just 'rm -rf venv')"
+    echo "  - Easy to delete if you want to start fresh (just 'rm -rf .venv')"
     echo "  - Industry best practice for Python development"
     echo ""
     echo "The venv will be created in: $SCRIPT_DIR/$VENV_DIR"

--- a/start_services_local.bat
+++ b/start_services_local.bat
@@ -23,18 +23,24 @@ REM --------------------------------------------------------------------
 REM Step 1: Verify that the environment has been installed
 REM --------------------------------------------------------------------
 echo [Verifying installation...]
-if not exist "%VENV_DIR%\Scripts\python.exe" (
-    echo [ERROR] Virtual environment not found!
-    echo    It looks like the installation hasn't been run yet.
-    echo    Please run 'install_windows_local.bat' once before starting services.
-    echo.
-    pause
-    exit /b 1
+if exist "%VENV_DIR%\Scripts\python.exe" (
+    REM Virtual environment exists - use it
+    SET PYTHON_EXE="%VENV_DIR%\Scripts\python.exe"
+    echo [OK] Virtual environment found. Using Python from: %PYTHON_EXE%
+) else (
+    REM No venv - check if system Python is available
+    where py >nul 2>&1
+    if errorlevel 1 (
+        echo [ERROR] Python not found!
+        echo    Please run 'install.bat' to set up the environment first.
+        echo.
+        pause
+        exit /b 1
+    )
+    REM Use system Python
+    SET PYTHON_EXE=py -3
+    echo [OK] Using system Python (no venv detected^)
 )
-
-REM Set the Python command to the one INSIDE our venv for reliability
-SET PYTHON_EXE="%VENV_DIR%\Scripts\python.exe"
-echo [OK] Environment found. Using Python from: %PYTHON_EXE%
 echo.
 
 REM --------------------------------------------------------------------
@@ -57,8 +63,15 @@ if exist "api\" (
 
 REM Start Next.js frontend
 if exist "frontend\" (
-    echo [Frontend] Starting Next.js frontend on http://localhost:3000...
-    start "Ktiseos Frontend" /MIN cmd /c "cd frontend && npm start"
+    REM Check if npm is available
+    where npm >nul 2>&1
+    if errorlevel 1 (
+        echo [Warning] npm not found - skipping frontend startup.
+        echo            Install Node.js 18+ from https://nodejs.org to enable frontend.
+    ) else (
+        echo [Frontend] Starting Next.js frontend on http://localhost:3000...
+        start "Ktiseos Frontend" /MIN cmd /c "cd frontend && npm start"
+    )
 )
 
 echo.

--- a/start_services_local.sh
+++ b/start_services_local.sh
@@ -18,22 +18,23 @@ echo ""
 # Step 1: Verify that the environment has been installed
 # --------------------------------------------------------------------
 echo "[Verifying installation...]"
-if [ ! -d "$VENV_DIR/bin" ]; then
-    echo "[ERROR] Virtual environment not found!"
-    echo "   It looks like the installation hasn't been run yet."
-    echo "   Please run './install.sh' once before starting services."
-    echo ""
-    exit 1
+if [ -d "$VENV_DIR/bin" ]; then
+    echo "[OK] Virtual environment found. Activating..."
+    source "$VENV_DIR/bin/activate"
+    PYTHON_CMD="python"
+    echo "   Python executable: $(which python)"
+else
+    echo "[OK] No virtual environment found. Using system Python."
+    # Verify system Python is available
+    if ! command -v python3 &> /dev/null; then
+        echo "[ERROR] Python 3 not found!"
+        echo "   Please run './install.sh' to set up the environment first."
+        echo ""
+        exit 1
+    fi
+    PYTHON_CMD="python3"
+    echo "   Python executable: $(which python3)"
 fi
-echo "[OK] Environment found."
-echo ""
-
-# --------------------------------------------------------------------
-# Step 2: Activate the Virtual Environment
-# --------------------------------------------------------------------
-echo "[Activating virtual environment...]"
-source "$VENV_DIR/bin/activate"
-echo "   Python executable: $(which python)"
 echo ""
 
 # --------------------------------------------------------------------
@@ -55,16 +56,21 @@ trap 'echo "\n[INFO] Shutting down services..."; pkill -P $$; exit' SIGINT
 # Start FastAPI backend in the background
 if [ -d "api" ]; then
     echo "[Backend] Starting FastAPI backend on http://localhost:8000..."
-    # Now 'python' correctly refers to the venv's python
-    python -m uvicorn api.main:app --host 127.0.0.1 --port 8000 --reload &
+    $PYTHON_CMD -m uvicorn api.main:app --host 127.0.0.1 --port 8000 --reload &
 else
     echo "[Warning] API directory not found - skipping backend startup."
 fi
 
 # Start Next.js frontend in the background
 if [ -d "frontend" ]; then
-    echo "[Frontend] Starting Next.js frontend on http://localhost:3000..."
-    (cd frontend && npm start &)
+    # Check if npm is available
+    if ! command -v npm &> /dev/null; then
+        echo "[Warning] npm not found - skipping frontend startup."
+        echo "          Install Node.js 18+ to enable frontend."
+    else
+        echo "[Frontend] Starting Next.js frontend on http://localhost:3000..."
+        (cd frontend && npm start &)
+    fi
 else
     echo "[Warning] Frontend directory not found - skipping frontend startup."
 fi


### PR DESCRIPTION
Fixed 8 critical bugs discovered during Issue #100 investigation:

1. **CRITICAL: venv directory mismatch**
   - install.bat/sh now create .venv (not venv)
   - Matches start_services_local.* expectations
   - Fixes "Virtual environment not found" errors

2. **CRITICAL: Python version selector too specific**
   - Changed py -3.10 to py -3 in install.bat
   - Now works with Python 3.10, 3.11, 3.12+

3. **Start scripts now support --no-venv**
   - start_services_local.* fall back to system Python if no venv
   - No longer exit with error when venv not found
   - Support users who chose --no-venv during install

4. **npm detection in start scripts**
   - Check for npm before attempting frontend startup
   - Graceful warning instead of cryptic errors
   - Backend still works without Node.js installed

5. **README: Fixed wrong installer references**
   - Removed outdated installer_local_linux.py references
   - Updated to modern ./install.sh approach
   - Simplified venv instructions (now automatic)

6. **Path quoting improvements**
   - Added quotes around VENV_DIR paths in install.bat
   - Fixes edge case with spaces in project path

7. **Consistent .venv messaging**
   - Fixed install.sh to reference .venv in user messages
   - All scripts now consistently use .venv

8. **README: Updated to match new installer flow**
   - Simplified instructions (installers now interactive)
   - Removed manual venv creation steps
   - Updated to show --no-venv flag for opt-out

Closes #100