### PR TITLE
fix: Explicitly bind Next.js server to 0.0.0.0 for VastAI port forwarding

### DIFF
--- a/start_services_vastai.sh
+++ b/start_services_vastai.sh
@@ -89,7 +89,7 @@ if [ -d "frontend" ]; then
 
         # Use production start mode, not development (only if build succeeded)
         if [ -d ".next" ]; then
-            npm run start &
+            HOSTNAME=0.0.0.0 PORT=3000 npm run start &
             FRONTEND_PID=$!
             echo "   Frontend PID: $FRONTEND_PID"
             cd ..

--- a/vastai_setup.sh
+++ b/vastai_setup.sh
@@ -226,7 +226,7 @@ sleep 2
 # Start frontend (using custom server with WebSocket proxy)
 echo "[$(date)] Starting Next.js frontend on port 3000 (custom server)..." | tee -a /workspace/logs/supervisor.log
 cd frontend || exit 1
-NODE_ENV=production node server.js 2>&1 | tee -a /workspace/logs/frontend.log &
+HOSTNAME=0.0.0.0 PORT=3000 NODE_ENV=production node server.js 2>&1 | tee -a /workspace/logs/frontend.log &
 FRONTEND_PID=$!
 
 # Wait for both processes


### PR DESCRIPTION
## Summary
Fixes #112 - Frontend port 3000 unreachable on VastAI instances

## Problem
The Next.js custom server wasn't explicitly binding to `0.0.0.0`, causing VastAI's port forwarding to fail. The API on port 8000 worked fine, but the frontend timed out or returned Cloudflare errors.

## Solution
Explicitly set `HOSTNAME=0.0.0.0` and `PORT=3000` environment variables when starting the Next.js custom server in both:
- `vastai_setup.sh` (supervisor startup script)
- `start_services_vastai.sh` (manual startup script)

## Changes
- vastai_setup.sh:229 - Added env vars to supervisor script
- start_services_vastai.sh:92 - Added env vars to manual startup

## Testing
After pulling this fix on VastAI:
1. `supervisorctl restart ktiseos-nyx`
2. Verify frontend logs show binding to 0.0.0.0
3. Access frontend via VastAI port 3000 proxy URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)