### PR TITLE
fix: Remove standalone mode conflicting with custom server

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
   },
 
   // 🚀 PERFORMANCE: Production optimizations
-  output: 'standalone', // Reduces deployment size by 80%+
+  // Note: 'standalone' mode conflicts with custom server.js (needed for WebSocket proxying)
   compress: true,       // Enable gzip compression
   productionBrowserSourceMaps: false, // Disable source maps in production (saves ~40% size)
 


### PR DESCRIPTION
The 'output: standalone' configuration in next.config.js conflicts with our custom server.js which is required for WebSocket proxying to the FastAPI backend. Removed standalone mode to allow custom server to work.