### PR TITLE
fix: Hardcode 0.0.0.0 binding for production to avoid Docker HOSTNAME…

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -20,7 +20,9 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 
 // Environment setup
 const dev = process.env.NODE_ENV !== 'production';
-const hostname = process.env.HOSTNAME || '0.0.0.0';
+// In production (Docker/VastAI), always bind to 0.0.0.0 for container networking
+// In dev, use localhost. Don't use HOSTNAME env var (Docker sets it to container ID)
+const hostname = dev ? 'localhost' : '0.0.0.0';
 const port = parseInt(process.env.PORT || '3000', 10);
 const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:8000';
 

--- a/start_services_vastai.sh
+++ b/start_services_vastai.sh
@@ -89,7 +89,7 @@ if [ -d "frontend" ]; then
 
         # Use production start mode, not development (only if build succeeded)
         if [ -d ".next" ]; then
-            HOSTNAME=0.0.0.0 PORT=3000 npm run start &
+            NODE_ENV=production npm run start &
             FRONTEND_PID=$!
             echo "   Frontend PID: $FRONTEND_PID"
             cd ..

--- a/vastai_setup.sh
+++ b/vastai_setup.sh
@@ -226,7 +226,7 @@ sleep 2
 # Start frontend (using custom server with WebSocket proxy)
 echo "[$(date)] Starting Next.js frontend on port 3000 (custom server)..." | tee -a /workspace/logs/supervisor.log
 cd frontend || exit 1
-HOSTNAME=0.0.0.0 PORT=3000 NODE_ENV=production node server.js 2>&1 | tee -a /workspace/logs/frontend.log &
+NODE_ENV=production node server.js 2>&1 | tee -a /workspace/logs/frontend.log &
 FRONTEND_PID=$!
 
 # Wait for both processes


### PR DESCRIPTION
… conflict

Docker sets HOSTNAME env var to the container ID, which was causing the Next.js server to bind to the container ID instead of 0.0.0.0.

Solution: Hardcode binding behavior based on NODE_ENV:
- Production (Docker/VastAI): Always bind to 0.0.0.0
- Development: Use localhost

This avoids fighting with Docker's environment while ensuring proper container networking for VastAI deployments.