### PR TITLE
fix: Complete TOML generation for bucketing and fix vae_batch_size de…

### DIFF
--- a/frontend/store/trainingStore.ts
+++ b/frontend/store/trainingStore.ts
@@ -109,7 +109,7 @@ const defaultConfig: TrainingConfig = {
   lowram: false,
   max_data_loader_n_workers: 8,
   persistent_data_loader_workers: 0,
-  vae_batch_size: 0,
+  vae_batch_size: 1,
   min_timestep: 0,
   max_timestep: 1000,
   ae_path: '',

--- a/services/trainers/kohya_toml.py
+++ b/services/trainers/kohya_toml.py
@@ -55,6 +55,34 @@ class KohyaTOMLGenerator:
         dataset["resolution"] = self.config.resolution
         dataset["batch_size"] = self.config.train_batch_size
         dataset["enable_bucket"] = True # Force bucketing enabled
+        dataset["min_bucket_reso"] = self.config.min_bucket_reso
+        dataset["max_bucket_reso"] = self.config.max_bucket_reso
+        if self.config.bucket_reso_steps:
+            dataset["bucket_reso_steps"] = self.config.bucket_reso_steps
+        if self.config.bucket_no_upscale:
+            dataset["bucket_no_upscale"] = True
+
+        # Augmentation settings
+        if self.config.flip_aug:
+            dataset["flip_aug"] = True
+        if self.config.random_crop:
+            dataset["random_crop"] = True
+        if self.config.color_aug:
+            dataset["color_aug"] = True
+
+        # Caption settings
+        if self.config.caption_dropout_rate > 0:
+            dataset["caption_dropout_rate"] = self.config.caption_dropout_rate
+        if self.config.caption_tag_dropout_rate > 0:
+            dataset["caption_tag_dropout_rate"] = self.config.caption_tag_dropout_rate
+        if self.config.caption_dropout_every_n_epochs > 0:
+            dataset["caption_dropout_every_n_epochs"] = self.config.caption_dropout_every_n_epochs
+        if self.config.keep_tokens_separator != "|||":
+            dataset["keep_tokens_separator"] = self.config.keep_tokens_separator
+        if self.config.secondary_separator:
+            dataset["secondary_separator"] = self.config.secondary_separator
+        if self.config.enable_wildcard:
+            dataset["enable_wildcard"] = True
 
         # [[datasets.subsets]] list
         subsets_aot = tomlkit.aot()


### PR DESCRIPTION
…fault

Fixed critical training failures caused by incomplete dataset TOML generation and invalid default values.

Backend TOML generation fixes (services/trainers/kohya_toml.py):
- Added min_bucket_reso and max_bucket_reso to dataset TOML (prevents AR errors)
- Added bucket_reso_steps and bucket_no_upscale (conditional)
- Added augmentation settings: flip_aug, random_crop, color_aug
- Added caption dropout settings: caption_dropout_rate, caption_tag_dropout_rate, caption_dropout_every_n_epochs
- Added caption separators: keep_tokens_separator, secondary_separator
- Added enable_wildcard flag

Frontend store fixes (frontend/store/trainingStore.ts):
- Changed vae_batch_size default from 0 to 1 (backend validation requires >= 1)
- Fixes 422 Unprocessable Entity errors on config auto-save

These missing parameters were causing:
- "mean ar error" failures during training (missing bucket resolution limits)
- 422 validation errors preventing config saves
- Loss of form data when switching between training tabs

Tested on VastAI with SDXL training - bucketing now works correctly.