### PR TITLE
fix: Remove auto-kill process logic from startup scripts

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -39,16 +39,6 @@ if ! python -c "import uvicorn, fastapi" 2>/dev/null; then
 fi
 
 # --------------------------------------------------------------------
-# Cleanup
-# --------------------------------------------------------------------
-echo "🧹 Cleaning up ports 8000 and 3000..."
-lsof -ti:8000 2>/dev/null | xargs kill -9 2>/dev/null || true
-lsof -ti:3000 2>/dev/null | xargs kill -9 2>/dev/null || true
-pkill -f "uvicorn.*api.main" 2>/dev/null || true
-pkill -f "node.*next" 2>/dev/null || true
-sleep 3
-
-# --------------------------------------------------------------------
 # Backend
 # --------------------------------------------------------------------
 if [ -d "api" ]; then

--- a/start_services_local.sh
+++ b/start_services_local.sh
@@ -38,16 +38,7 @@ fi
 echo ""
 
 # --------------------------------------------------------------------
-# Step 3: Clean up any existing processes
-# --------------------------------------------------------------------
-echo "[Cleanup] Stopping any existing services on ports 8000 & 3000..."
-# Use pkill for simplicity and robustness. The '|| true' prevents script exit if no process is found.
-pkill -f "uvicorn api.main:app" || true
-pkill -f "npm.*start" || true
-sleep 1
-
-# --------------------------------------------------------------------
-# Step 4: Start Services
+# Step 3: Start Services
 # --------------------------------------------------------------------
 
 # Trap SIGINT (Ctrl+C) to gracefully shut down background processes

--- a/start_services_vastai.sh
+++ b/start_services_vastai.sh
@@ -9,19 +9,6 @@ echo "🚀 Starting Ktiseos-Nyx-Trainer Services (Vast.ai/Cloud)..."
 echo "=========================================="
 
 # --------------------------------------------------------------------
-# Step 0: Clean up any existing processes using the ports
-# --------------------------------------------------------------------
-echo "🧹 Cleaning up any existing processes on ports 8000 and 3000..."
-lsof -ti:8000 | xargs kill -9 2>/dev/null || true
-lsof -ti:3000 | xargs kill -9 2>/dev/null || true
-
-# Also kill any existing uvicorn or next processes to prevent conflicts
-pkill -f "uvicorn.*api.main" 2>/dev/null || true
-pkill -f "node.*next" 2>/dev/null || true
-
-sleep 3  # Give time for processes to terminate
-
-# --------------------------------------------------------------------
 # Step 1: Ensure environment is set up via installer_remote.py
 # Note: VastAI PyTorch template might already have venv activated.
 # The installer_remote.py will verify and install missing components.


### PR DESCRIPTION
- Remove pkill/taskkill from start_services_local.sh
- Remove pkill/lsof kill from start_services_vastai.sh
- Remove cleanup section from start.sh
- Keep kill logic in restart.sh as fallback for stuck processes

Users should manually stop services or use restart.sh if ports are busy.