### PR TITLE
fix: VastAI deployment failure + pre-flight diagnostics

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,6 @@
     "gsap": "^3.14.2",
     "http-proxy-middleware": "^3.0.5",
     "lexical": "^0.39.0",
-    "lightningcss-win32-x64-msvc": "^1.31.1",
     "lucide-react": "^0.561.0",
     "motion": "^12.23.26",
     "next": "15.5.10",

--- a/install.bat
+++ b/install.bat
@@ -147,6 +147,12 @@ if %errorlevel% neq 0 (
     echo   3. Multiple Python installations conflicting
     echo      Solution: Check "python --version" and "py --list" in CMD
     echo.
+    echo   4. "Access is denied" during install
+    echo      - Make sure the project is NOT in OneDrive/Dropbox/Google Drive
+    echo      - Close any editors ^(VS Code^) that may lock files in the project
+    echo      - Try running this script as Administrator ^(right-click ^> Run as admin^)
+    echo      - Avoid installing to C:\Program Files or other protected folders
+    echo.
     echo Check the log file in logs/ folder for detailed error information.
     echo ======================================================================
 ) else (

--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,47 @@ if [ "$MIN_VERSION_COMPARE" != "$MIN_PYTHON_VERSION" ]; then
 fi
 echo ""
 
+# --- Pre-flight: Permission & Environment Checks ---
+echo "[Pre-flight checks...]"
+
+# Check write permissions
+if ! touch "$SCRIPT_DIR/.write_test" 2>/dev/null; then
+    echo "❌ ERROR: Cannot write to project folder!"
+    echo "   Path: $SCRIPT_DIR"
+    echo ""
+    echo "   This usually means file ownership doesn't match your user."
+    echo "   Fix: sudo chown -R $(whoami):$(id -gn) $SCRIPT_DIR"
+    echo ""
+    exit 1
+else
+    rm -f "$SCRIPT_DIR/.write_test"
+fi
+
+# Check ownership mismatch (most common Linux "Permission denied")
+DIR_OWNER=$(stat -c '%u' "$SCRIPT_DIR" 2>/dev/null || stat -f '%u' "$SCRIPT_DIR" 2>/dev/null || echo "unknown")
+CURRENT_UID=$(id -u)
+if [ "$DIR_OWNER" != "unknown" ] && [ "$DIR_OWNER" != "$CURRENT_UID" ]; then
+    OWNER_NAME=$(id -un "$DIR_OWNER" 2>/dev/null || echo "uid:$DIR_OWNER")
+    echo "⚠️  WARNING: File ownership mismatch!"
+    echo "   Project files owned by: $OWNER_NAME (uid:$DIR_OWNER)"
+    echo "   You are running as: $(whoami) (uid:$CURRENT_UID)"
+    echo ""
+    echo "   This may cause 'Permission denied' errors during install."
+    echo "   Fix: sudo chown -R $(whoami):$(id -gn) $SCRIPT_DIR"
+    echo ""
+fi
+
+# Warn against running installer as root (unless on VastAI/Docker)
+if [ "$CURRENT_UID" = "0" ] && [ ! -f "/.dockerenv" ] && [ ! -d "/workspace" ]; then
+    echo "⚠️  WARNING: Running as root on a non-container system."
+    echo "   This will create files owned by root that your normal user can't modify."
+    echo "   Consider running as your regular user instead."
+    echo ""
+fi
+
+echo "[Pre-flight checks complete.]"
+echo ""
+
 # --- Interactive venv prompt if not specified ---
 if [ -z "$USE_VENV" ]; then
     echo "Virtual Environment Recommendation:"

--- a/installer_windows_local.py
+++ b/installer_windows_local.py
@@ -468,7 +468,20 @@ class LocalWindowsInstaller:
         if not os.path.exists(node_modules):
             self.logger.info("Installing frontend dependencies...")
             print(" 📦 Installing frontend (Next.js) dependencies...")
-            success = self.run_command([npm_exe, "install"], "Installing npm packages", cwd=frontend_dir)
+            success = self.run_command(
+                [npm_exe, "install", "--legacy-peer-deps"],
+                "Installing npm packages",
+                cwd=frontend_dir,
+            )
+            if not success:
+                # Retry with --force for stubborn platform-specific dep issues
+                self.logger.warning("npm install failed, retrying with --force...")
+                print(" ⚠️  Retrying npm install with --force...")
+                success = self.run_command(
+                    [npm_exe, "install", "--legacy-peer-deps", "--force"],
+                    "Installing npm packages (force)",
+                    cwd=frontend_dir,
+                )
             return success
         else:
             self.logger.info("Frontend dependencies already installed.")

--- a/start_services_local.bat
+++ b/start_services_local.bat
@@ -3,25 +3,120 @@ title Ktiseos-Nyx-Trainer Local Services
 
 REM ======================================================================
 REM This script STARTS the services. It assumes the one-time installer
-REM ('install_windows_local.bat') has already been run successfully.
+REM ('install.bat') has already been run successfully.
 REM
 REM It correctly uses the Python executable from the virtual environment (.venv)
 REM to ensure all dependencies are found and services run correctly.
 REM ======================================================================
 
-SETLOCAL
+SETLOCAL EnableDelayedExpansion
 
 REM Define the virtual environment directory
 SET VENV_DIR=%~dp0.venv
+SET HAS_WARNINGS=0
 
 echo ==========================================
 echo Starting Ktiseos-Nyx-Trainer Services...
 echo ==========================================
 echo.
 
-REM --------------------------------------------------------------------
+REM ====================================================================
+REM  PRE-FLIGHT CHECKS - Catch common issues BEFORE they become cryptic
+REM ====================================================================
+echo [Pre-flight checks...]
+echo.
+
+REM --- Check: Cloud sync folder (OneDrive, Dropbox, Google Drive) ---
+REM These lock files during sync and cause "Access is denied" on writes
+echo %CD% | findstr /I "OneDrive" >nul 2>&1
+if not errorlevel 1 (
+    echo [WARNING] Project is inside a OneDrive folder!
+    echo           OneDrive can lock files during sync, causing "Access is denied".
+    echo           Recommendation: Move the project to a non-synced folder
+    echo           ^(e.g. C:\Projects or D:\Dev^)
+    echo.
+    SET HAS_WARNINGS=1
+)
+echo %CD% | findstr /I "Dropbox" >nul 2>&1
+if not errorlevel 1 (
+    echo [WARNING] Project is inside a Dropbox folder!
+    echo           Dropbox can lock files during sync, causing "Access is denied".
+    echo           Recommendation: Move the project to a non-synced folder.
+    echo.
+    SET HAS_WARNINGS=1
+)
+echo %CD% | findstr /I "Google Drive" >nul 2>&1
+if not errorlevel 1 (
+    echo [WARNING] Project is inside a Google Drive folder!
+    echo           Google Drive can lock files during sync, causing "Access is denied".
+    echo           Recommendation: Move the project to a non-synced folder.
+    echo.
+    SET HAS_WARNINGS=1
+)
+
+REM --- Check: Write permissions (can we actually write here?) ---
+echo test > "%~dp0.write_test" 2>nul
+if errorlevel 1 (
+    echo [ERROR] Cannot write to project folder!
+    echo         Path: %~dp0
+    echo.
+    echo         This usually means:
+    echo           - The folder is read-only or controlled by another program
+    echo           - You need to run as Administrator for this location
+    echo           - The folder is on a read-only network drive
+    echo.
+    echo         Fix: Move the project to a folder you own, like:
+    echo              C:\Users\%USERNAME%\Projects\Ktiseos-Nyx-Trainer
+    echo.
+    pause
+    exit /b 1
+) else (
+    del "%~dp0.write_test" 2>nul
+)
+
+REM --- Check: Ports already in use ---
+netstat -ano 2>nul | findstr ":8000 " | findstr "LISTENING" >nul 2>&1
+if not errorlevel 1 (
+    echo [WARNING] Port 8000 is already in use!
+    echo           Something is already listening there. The backend may fail to start.
+    echo           To find what's using it: netstat -ano ^| findstr ":8000"
+    echo.
+    SET HAS_WARNINGS=1
+)
+
+netstat -ano 2>nul | findstr ":3000 " | findstr "LISTENING" >nul 2>&1
+if not errorlevel 1 (
+    echo [WARNING] Port 3000 is already in use!
+    echo           Something is already listening there. The frontend may fail to start.
+    echo           To find what's using it: netstat -ano ^| findstr ":3000"
+    echo.
+    SET HAS_WARNINGS=1
+)
+
+REM --- Check: Stale node processes (leftover from crash) ---
+tasklist /FI "IMAGENAME eq node.exe" 2>nul | findstr /I "node.exe" >nul 2>&1
+if not errorlevel 1 (
+    echo [INFO] Node.js processes are already running.
+    echo        If you're restarting, old processes may hold file locks.
+    echo        If the frontend fails with "Access is denied" or "EBUSY",
+    echo        close all Node terminals or run: taskkill /F /IM node.exe
+    echo.
+)
+
+if "%HAS_WARNINGS%"=="1" (
+    echo ------------------------------------------
+    echo   Warnings found. Services may still work,
+    echo   but check above if you hit errors.
+    echo ------------------------------------------
+    echo.
+)
+
+echo [Pre-flight checks complete.]
+echo.
+
+REM ====================================================================
 REM Step 1: Verify that the environment has been installed
-REM --------------------------------------------------------------------
+REM ====================================================================
 echo [Verifying installation...]
 if exist "%VENV_DIR%\Scripts\python.exe" (
     REM Virtual environment exists - use it
@@ -43,9 +138,9 @@ if exist "%VENV_DIR%\Scripts\python.exe" (
 )
 echo.
 
-REM --------------------------------------------------------------------
-REM Step 2: Start Services using the correct Python
-REM --------------------------------------------------------------------
+REM ====================================================================
+REM Step 2: Start Services
+REM ====================================================================
 
 REM Start FastAPI backend
 if exist "api\" (
@@ -59,8 +154,22 @@ if exist "frontend\" (
     where npm >nul 2>&1
     if errorlevel 1 (
         echo [Warning] npm not found - skipping frontend startup.
-        echo            Install Node.js 18+ from https://nodejs.org to enable frontend.
+        echo            Install Node.js 20+ from https://nodejs.org to enable frontend.
     ) else (
+        REM Check if node_modules exists
+        if not exist "frontend\node_modules\next" (
+            echo [Frontend] Dependencies missing, running npm install...
+            pushd frontend
+            npm install --legacy-peer-deps
+            popd
+        )
+        REM Check if .next build exists
+        if not exist "frontend\.next" (
+            echo [Frontend] No build found, running npm run build...
+            pushd frontend
+            npm run build
+            popd
+        )
         echo [Frontend] Starting Next.js frontend on http://localhost:3000...
         start "Ktiseos Frontend" /MIN cmd /c "cd frontend && npm start"
     )
@@ -71,8 +180,9 @@ echo ==========================================
 echo [SUCCESS] Local Services Started!
 echo ==========================================
 echo.
-echo >> Access the UI at: http://localhost:3000
-echo >> API Docs available at: http://localhost:8000/docs
+echo   Access the UI at: http://localhost:3000
+echo   API Docs available at: http://localhost:8000/docs
 echo.
-echo [INFO] To stop services, simply close the new minimized command windows.
+echo [INFO] To stop services, close the minimized command windows
+echo        or press Ctrl+C in each one.
 echo.

--- a/start_services_local.sh
+++ b/start_services_local.sh
@@ -7,6 +7,7 @@ set -e
 
 # --- Configuration ---
 VENV_DIR=".venv"
+HAS_WARNINGS=0
 
 # --- Main Script ---
 echo "=========================================="
@@ -14,9 +15,105 @@ echo "Starting Ktiseos-Nyx-Trainer Services (Local)..."
 echo "=========================================="
 echo ""
 
-# --------------------------------------------------------------------
+# ====================================================================
+#  PRE-FLIGHT CHECKS - Catch common issues BEFORE they become cryptic
+# ====================================================================
+echo "[Pre-flight checks...]"
+echo ""
+
+# --- Check: File ownership mismatch (root vs user) ---
+# This is the #1 cause of "Permission denied" on Linux.
+# Happens when: cloned as root, running as user (or vice versa)
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -d "$PROJECT_DIR/frontend" ]; then
+    DIR_OWNER=$(stat -c '%u' "$PROJECT_DIR/frontend" 2>/dev/null || stat -f '%u' "$PROJECT_DIR/frontend" 2>/dev/null || echo "unknown")
+    CURRENT_UID=$(id -u)
+    if [ "$DIR_OWNER" != "unknown" ] && [ "$DIR_OWNER" != "$CURRENT_UID" ]; then
+        OWNER_NAME=$(id -un "$DIR_OWNER" 2>/dev/null || echo "uid:$DIR_OWNER")
+        echo "[WARNING] File ownership mismatch!"
+        echo "          Project files are owned by: $OWNER_NAME (uid:$DIR_OWNER)"
+        echo "          You are running as: $(whoami) (uid:$CURRENT_UID)"
+        echo ""
+        echo "          This WILL cause 'Permission denied' errors."
+        echo "          Fix: sudo chown -R $(whoami):$(id -gn) $PROJECT_DIR"
+        echo ""
+        HAS_WARNINGS=1
+    fi
+fi
+
+# --- Check: Write permissions ---
+if ! touch "$PROJECT_DIR/.write_test" 2>/dev/null; then
+    echo "[ERROR] Cannot write to project folder!"
+    echo "        Path: $PROJECT_DIR"
+    echo ""
+    echo "        Fix: sudo chown -R $(whoami):$(id -gn) $PROJECT_DIR"
+    echo "        Or:  chmod -R u+w $PROJECT_DIR"
+    echo ""
+    exit 1
+else
+    rm -f "$PROJECT_DIR/.write_test"
+fi
+
+# --- Check: node_modules ownership (common after sudo npm install) ---
+if [ -d "$PROJECT_DIR/frontend/node_modules" ]; then
+    NM_OWNER=$(stat -c '%u' "$PROJECT_DIR/frontend/node_modules" 2>/dev/null || stat -f '%u' "$PROJECT_DIR/frontend/node_modules" 2>/dev/null || echo "unknown")
+    if [ "$NM_OWNER" != "unknown" ] && [ "$NM_OWNER" != "$(id -u)" ]; then
+        echo "[WARNING] frontend/node_modules is owned by a different user!"
+        echo "          This happens if 'npm install' was run as root/sudo."
+        echo "          Fix: sudo chown -R $(whoami):$(id -gn) $PROJECT_DIR/frontend/node_modules"
+        echo "          Or delete and reinstall: rm -rf frontend/node_modules && cd frontend && npm install"
+        echo ""
+        HAS_WARNINGS=1
+    fi
+fi
+
+# --- Check: Ports already in use ---
+if command -v ss &> /dev/null; then
+    PORT_CHECK_CMD="ss -tlnp"
+elif command -v netstat &> /dev/null; then
+    PORT_CHECK_CMD="netstat -tlnp"
+else
+    PORT_CHECK_CMD=""
+fi
+
+if [ -n "$PORT_CHECK_CMD" ]; then
+    if $PORT_CHECK_CMD 2>/dev/null | grep -q ":8000 "; then
+        echo "[WARNING] Port 8000 is already in use!"
+        echo "          Something is already listening there. The backend may fail."
+        echo "          Check with: $PORT_CHECK_CMD 2>/dev/null | grep :8000"
+        echo ""
+        HAS_WARNINGS=1
+    fi
+    if $PORT_CHECK_CMD 2>/dev/null | grep -q ":3000 "; then
+        echo "[WARNING] Port 3000 is already in use!"
+        echo "          Something is already listening there. The frontend may fail."
+        echo "          Check with: $PORT_CHECK_CMD 2>/dev/null | grep :3000"
+        echo ""
+        HAS_WARNINGS=1
+    fi
+fi
+
+# --- Check: Stale node processes ---
+if pgrep -f "node.*server.js" > /dev/null 2>&1 || pgrep -f "next-server" > /dev/null 2>&1; then
+    echo "[INFO] Existing Node.js processes found (possibly from a previous run)."
+    echo "       If the frontend fails, try: pkill -f 'node.*server.js'"
+    echo ""
+fi
+
+if [ "$HAS_WARNINGS" = "1" ]; then
+    echo "------------------------------------------"
+    echo "  Warnings found. Services may still work,"
+    echo "  but check above if you hit errors."
+    echo "------------------------------------------"
+    echo ""
+fi
+
+echo "[Pre-flight checks complete.]"
+echo ""
+
+# ====================================================================
 # Step 1: Verify that the environment has been installed
-# --------------------------------------------------------------------
+# ====================================================================
 echo "[Verifying installation...]"
 if [ -d "$VENV_DIR/bin" ]; then
     echo "[OK] Virtual environment found. Activating..."
@@ -37,9 +134,9 @@ else
 fi
 echo ""
 
-# --------------------------------------------------------------------
-# Step 3: Start Services
-# --------------------------------------------------------------------
+# ====================================================================
+# Step 2: Start Services
+# ====================================================================
 
 # Trap SIGINT (Ctrl+C) to gracefully shut down background processes
 trap 'echo "\n[INFO] Shutting down services..."; pkill -P $$; exit' SIGINT
@@ -57,8 +154,18 @@ if [ -d "frontend" ]; then
     # Check if npm is available
     if ! command -v npm &> /dev/null; then
         echo "[Warning] npm not found - skipping frontend startup."
-        echo "          Install Node.js 18+ to enable frontend."
+        echo "          Install Node.js 20+ to enable frontend."
     else
+        # Auto-install deps if missing
+        if [ ! -d "frontend/node_modules/next" ]; then
+            echo "[Frontend] Dependencies missing, running npm install..."
+            (cd frontend && npm install --legacy-peer-deps)
+        fi
+        # Auto-build if missing
+        if [ ! -d "frontend/.next" ]; then
+            echo "[Frontend] No build found, running npm run build..."
+            (cd frontend && npm run build)
+        fi
         echo "[Frontend] Starting Next.js frontend on http://localhost:3000..."
         (cd frontend && npm start &)
     fi

--- a/start_services_vastai.sh
+++ b/start_services_vastai.sh
@@ -66,6 +66,12 @@ if [ -d "frontend" ]; then
         # Check if build exists
         if [ ! -d ".next" ]; then
             echo "   ⚠️  No build found, running npm run build first..."
+            # Ensure node_modules exists (may need install if lockfile was platform-specific)
+            if [ ! -d "node_modules" ] || [ ! -d "node_modules/next" ]; then
+                echo "   📦 node_modules missing or incomplete, installing..."
+                rm -f package-lock.json
+                npm install --legacy-peer-deps || npm install --legacy-peer-deps --force || true
+            fi
             npm run build || {
                 echo "❌ Frontend build failed - skipping frontend startup"
                 cd ..

--- a/vastai_setup.sh
+++ b/vastai_setup.sh
@@ -145,7 +145,13 @@ provisioning_start() {
             echo "NPM version: $(npm --version)"
 
             echo "   Installing npm packages..."
-            npm ci --prefer-offline || npm install || {
+            # Remove stale lockfile from different OS to avoid platform-specific dep errors
+            # (e.g. lightningcss-win32-x64-msvc fails on Linux)
+            if [ -f "package-lock.json" ]; then
+                echo "   Removing package-lock.json (regenerating for this platform)..."
+                rm -f package-lock.json
+            fi
+            npm install --legacy-peer-deps || npm install --legacy-peer-deps --force || {
                 echo "⚠️  npm install failed, continuing anyway..."
             }
 


### PR DESCRIPTION
## Summary
- **Root cause fix**: Removed `lightningcss-win32-x64-msvc` from `package.json` — a Windows-only native binary that caused `EBADPLATFORM` on Linux, cascading into the entire VastAI frontend failing to start (`next: not found` → port 3000 never opens → cloudflared connection refused)
- **Hardened npm install** across all scripts: delete stale lockfile on VastAI, `--legacy-peer-deps` + `--force` fallback, node_modules existence checks before build
- **Added pre-flight diagnostics** to startup scripts (Windows + Linux) catching permission issues, port conflicts, and stale processes *before* they become cryptic errors
- **Production build fixes**, storage detection (RAM→disk), and lint cleanup from prior commits on this branch

## Changes
### VastAI / Cross-platform npm
- `frontend/package.json` — Removed platform-specific dependency
- `vastai_setup.sh` — Deletes stale lockfile, `--legacy-peer-deps` + `--force` fallback
- `start_services_vastai.sh` — Checks for missing node_modules before build

### Pre-flight diagnostics (new)
- `start_services_local.bat` — Cloud sync detection (OneDrive/Dropbox/Google Drive), write permission test, port-in-use checks, stale node.exe detection
- `start_services_local.sh` — File ownership mismatch, write permissions, node_modules ownership, port checks, stale process detection
- `install.sh` — Permission/ownership pre-flight checks with actionable fix commands
- `install.bat` — "Access is denied" troubleshooting guidance

### Windows installer
- `installer_windows_local.py` — `--legacy-peer-deps` + `--force` retry logic

## Test plan
- [ ] Rent a VastAI GPU instance and verify frontend starts successfully
- [ ] Run `install.bat` and `start_services_local.bat` on Windows
- [ ] Run `install.sh` and `start_services_local.sh` on Linux
- [ ] Verify pre-flight checks catch: port in use, stale processes, cloud sync folders



🤖 Generated with [Claude Code](https://claude.com/claude-code)