### PR TITLE
fix: Auto-download tagger models + fix server.js job manager import

### DIFF
--- a/frontend/lib/node-services/job-events.js
+++ b/frontend/lib/node-services/job-events.js
@@ -1,0 +1,30 @@
+/**
+ * Shared Job Event Bus - Plain JS module for cross-boundary sharing
+ *
+ * This module is intentionally plain JavaScript (not TypeScript) so that
+ * both server.js (plain JS) and Next.js API routes (compiled TS) can
+ * import the SAME singleton instance.
+ *
+ * The EventEmitter and jobs Map are shared via globalThis to ensure
+ * a single instance across the entire Node.js process.
+ */
+
+const { EventEmitter } = require('events');
+
+// Use globalThis to ensure singleton across require() boundaries
+if (!globalThis.__jobEvents) {
+  const events = new EventEmitter();
+  events.setMaxListeners(100);
+  globalThis.__jobEvents = events;
+}
+
+if (!globalThis.__jobsMap) {
+  globalThis.__jobsMap = new Map();
+}
+
+module.exports = {
+  /** Shared event emitter for job log/status/progress events */
+  jobEvents: globalThis.__jobEvents,
+  /** Shared jobs map (job ID -> job object) */
+  jobsMap: globalThis.__jobsMap,
+};

--- a/frontend/lib/node-services/job-manager.ts
+++ b/frontend/lib/node-services/job-manager.ts
@@ -13,6 +13,10 @@ import { spawn, ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import path from 'path';
 
+// Shared event bus and jobs map (plain JS for server.js compatibility)
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { jobEvents, jobsMap } = require('./job-events');
+
 // ========== Types ==========
 
 export type JobType = 'training' | 'tagging' | 'captioning_blip' | 'captioning_git' | 'lora_resize' | 'hf_upload';
@@ -58,9 +62,10 @@ export interface JobEventEmitter extends EventEmitter {
 // ========== Job Manager ==========
 
 class JobManager {
-  private jobs: Map<string, Job> = new Map();
+  // Use shared maps/events so server.js (plain JS) can access the same instances
+  private jobs: Map<string, Job> = jobsMap;
   private processes: Map<string, ChildProcess> = new Map();
-  public events: JobEventEmitter = new EventEmitter() as JobEventEmitter;
+  public events: JobEventEmitter = jobEvents as JobEventEmitter;
   private jobCounter = 0;
 
   /**

--- a/frontend/lib/node-services/tagging-service.ts
+++ b/frontend/lib/node-services/tagging-service.ts
@@ -11,6 +11,8 @@ import * as ort from 'onnxruntime-node';
 import sharp from 'sharp';
 import fs from 'fs/promises';
 import path from 'path';
+import https from 'https';
+import { createWriteStream } from 'fs';
 
 // ========== Types ==========
 
@@ -43,8 +45,83 @@ class TaggingService {
   private modelPath: string = '';
   private isInitialized: boolean = false;
 
+  // Files needed for ONNX inference
+  private static readonly REQUIRED_FILES = ['model.onnx', 'selected_tags.csv'];
+
+  /**
+   * Download a file from HuggingFace Hub
+   */
+  private async downloadFile(url: string, destPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const file = createWriteStream(destPath);
+      const request = (reqUrl: string) => {
+        https.get(reqUrl, (response) => {
+          // Follow redirects (HuggingFace uses them)
+          if (response.statusCode === 301 || response.statusCode === 302) {
+            const redirectUrl = response.headers.location;
+            if (redirectUrl) {
+              request(redirectUrl);
+              return;
+            }
+          }
+
+          if (response.statusCode !== 200) {
+            file.close();
+            fs.unlink(destPath).catch(() => {});
+            reject(new Error(`Download failed: HTTP ${response.statusCode} for ${url}`));
+            return;
+          }
+
+          const totalSize = parseInt(response.headers['content-length'] || '0', 10);
+          let downloaded = 0;
+
+          response.on('data', (chunk: Buffer) => {
+            downloaded += chunk.length;
+            if (totalSize > 0 && downloaded % (5 * 1024 * 1024) < chunk.length) {
+              const pct = ((downloaded / totalSize) * 100).toFixed(1);
+              console.log(`[Tagging] Downloading... ${pct}% (${(downloaded / 1024 / 1024).toFixed(1)}MB)`);
+            }
+          });
+
+          response.pipe(file);
+          file.on('finish', () => {
+            file.close();
+            resolve();
+          });
+        }).on('error', (err) => {
+          file.close();
+          fs.unlink(destPath).catch(() => {});
+          reject(err);
+        });
+      };
+      request(url);
+    });
+  }
+
+  /**
+   * Download model files from HuggingFace if not already present
+   */
+  private async ensureModelDownloaded(modelName: string, modelDir: string): Promise<void> {
+    await fs.mkdir(modelDir, { recursive: true });
+
+    for (const file of TaggingService.REQUIRED_FILES) {
+      const filePath = path.join(modelDir, file);
+      try {
+        await fs.access(filePath);
+        const stat = await fs.stat(filePath);
+        if (stat.size === 0) throw new Error('Empty file');
+      } catch {
+        const url = `https://huggingface.co/${modelName}/resolve/main/${file}`;
+        console.log(`[Tagging] Downloading ${file} from HuggingFace: ${modelName}`);
+        await this.downloadFile(url, filePath);
+        console.log(`[Tagging] Downloaded ${file} successfully`);
+      }
+    }
+  }
+
   /**
    * Initialize the WD14 model (run once per model)
+   * Auto-downloads from HuggingFace if not present.
    */
   async initModel(modelName: string): Promise<void> {
     if (this.isInitialized && this.modelPath.includes(modelName)) {
@@ -56,39 +133,31 @@ class TaggingService {
     const modelFile = path.join(modelDir, 'model.onnx');
     const csvFile = path.join(modelDir, 'selected_tags.csv');
 
-    try {
-      // Check if model exists
-      await fs.access(modelFile);
-      await fs.access(csvFile);
+    // Auto-download model files if missing
+    await this.ensureModelDownloaded(modelName, modelDir);
 
-      console.log(`[Tagging] Loading model: ${modelName}`);
+    console.log(`[Tagging] Loading model: ${modelName}`);
 
-      // Load ONNX Model (CPU execution - no CUDA needed!)
-      this.session = await ort.InferenceSession.create(modelFile, {
-        executionProviders: ['cpu'],
-      });
+    // Load ONNX Model (CPU execution - no CUDA needed!)
+    this.session = await ort.InferenceSession.create(modelFile, {
+      executionProviders: ['cpu'],
+    });
 
-      // Load Tags CSV
-      const csvContent = await fs.readFile(csvFile, 'utf-8');
-      this.tags = csvContent
-        .split('\n')
-        .slice(1) // Skip header
-        .map((line) => {
-          const parts = line.split(',');
-          return parts[1]?.trim(); // Tag name is in column 1
-        })
-        .filter((t) => t); // Filter empty lines
+    // Load Tags CSV
+    const csvContent = await fs.readFile(csvFile, 'utf-8');
+    this.tags = csvContent
+      .split('\n')
+      .slice(1) // Skip header
+      .map((line) => {
+        const parts = line.split(',');
+        return parts[1]?.trim(); // Tag name is in column 1
+      })
+      .filter((t) => t); // Filter empty lines
 
-      this.modelPath = modelFile;
-      this.isInitialized = true;
+    this.modelPath = modelFile;
+    this.isInitialized = true;
 
-      console.log(`[Tagging] Model loaded: ${this.tags.length} tags available`);
-    } catch (error) {
-      console.error(`[Tagging] Failed to load model:`, error);
-      throw new Error(
-        `Model not found: ${modelName}. Please download it first via the Models page.`
-      );
-    }
+    console.log(`[Tagging] Model loaded: ${this.tags.length} tags available`);
   }
 
   /**

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -124,9 +124,9 @@ app.prepare().then(() => {
 
     const jobId = match[1];
 
-    // Import job manager (lazy load to avoid circular deps)
-    const { jobManager } = require('./lib/node-services/job-manager');
-    const job = jobManager.getJob(jobId);
+    // Use shared event bus (plain JS, works across server.js and Next.js API routes)
+    const { jobEvents, jobsMap } = require('./lib/node-services/job-events');
+    const job = jobsMap.get(jobId);
 
     if (!job) {
       ws.send(JSON.stringify({ error: `Job ${jobId} not found` }));
@@ -165,16 +165,16 @@ app.prepare().then(() => {
       }
     };
 
-    jobManager.events.on('log', logListener);
-    jobManager.events.on('status', statusListener);
-    jobManager.events.on('progress', progressListener);
+    jobEvents.on('log', logListener);
+    jobEvents.on('status', statusListener);
+    jobEvents.on('progress', progressListener);
 
     // Handle client disconnect
     ws.on('close', () => {
       console.log(`🔌 WebSocket disconnected: ${pathname}`);
-      jobManager.events.removeListener('log', logListener);
-      jobManager.events.removeListener('status', statusListener);
-      jobManager.events.removeListener('progress', progressListener);
+      jobEvents.removeListener('log', logListener);
+      jobEvents.removeListener('status', statusListener);
+      jobEvents.removeListener('progress', progressListener);
     });
 
     // Handle ping/pong for connection health


### PR DESCRIPTION
1. Tagging service now auto-downloads model.onnx and selected_tags.csv from HuggingFace when not present, matching the Python tagger's behavior. No more "please download manually" errors.

2. Fixed server.js unable to require TypeScript job-manager.ts in production. Created shared job-events.js (plain JS) as a bridge between server.js and Next.js API routes using globalThis singleton.