### PR TITLE
Fix/vastai frontend binding 112

### DIFF
--- a/frontend/lib/node-services/job-events.js
+++ b/frontend/lib/node-services/job-events.js
@@ -15,6 +15,11 @@ const { EventEmitter } = require('events');
 if (!globalThis.__jobEvents) {
   const events = new EventEmitter();
   events.setMaxListeners(100);
+  // IMPORTANT: 'error' events on EventEmitter throw if no listener is attached.
+  // Add a default handler so job errors don't crash the process.
+  events.on('error', (jobId, errorMsg) => {
+    console.error(`[JobManager] Job ${jobId} error: ${errorMsg}`);
+  });
   globalThis.__jobEvents = events;
 }
 

--- a/frontend/lib/node-services/job-manager.ts
+++ b/frontend/lib/node-services/job-manager.ts
@@ -62,6 +62,11 @@ export interface JobEventEmitter extends EventEmitter {
 if (!globalThis.__jobEvents) {
   const events = new EventEmitter();
   events.setMaxListeners(100);
+  // IMPORTANT: 'error' events on EventEmitter throw if no listener is attached.
+  // Add a default handler so job errors don't crash the process.
+  events.on('error', (jobId: string, errorMsg: string) => {
+    console.error(`[JobManager] Job ${jobId} error: ${errorMsg}`);
+  });
   globalThis.__jobEvents = events;
 }
 if (!globalThis.__jobsMap) {

--- a/frontend/lib/node-services/tagging-service.ts
+++ b/frontend/lib/node-services/tagging-service.ts
@@ -56,10 +56,11 @@ class TaggingService {
       const file = createWriteStream(destPath);
       const request = (reqUrl: string) => {
         https.get(reqUrl, (response) => {
-          // Follow redirects (HuggingFace uses them)
-          if (response.statusCode === 301 || response.statusCode === 302) {
+          // Follow redirects (HuggingFace uses 301, 302, 303, 307, 308)
+          if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400) {
             const redirectUrl = response.headers.location;
             if (redirectUrl) {
+              response.resume(); // Drain the response to free the socket
               request(redirectUrl);
               return;
             }


### PR DESCRIPTION

  1. No more crash — the 'error' event now has a default listener instead of throwing
  2. Better redirects — handles all HuggingFace redirect types


  1. ERR_UNHANDLED_ERROR — Node.js EventEmitter has special behavior: emitting 'error' with no listener throws an         exception. The tagging route emits 'error' before the WebSocket connects, so there's no listener yet → boom.
  2. 404 still happening — the globalThis might not have been picked up, or the build is stale.                         