### PR TITLE
fix: Memory leak fixes + ONNX CUDA attempt (see #150)

### DIFF
--- a/frontend/app/dataset/[name]/auto-tag/page.tsx
+++ b/frontend/app/dataset/[name]/auto-tag/page.tsx
@@ -155,8 +155,12 @@ export default function AutoTagPage() {
     };
   }, []);
 
+  const MAX_LOGS = 500;
   const addLog = (msg: string) => {
-    setLogs(prev => [...prev, `[${new Date().toLocaleTimeString()}] ${msg}`]);
+    setLogs(prev => {
+      const next = [...prev, `[${new Date().toLocaleTimeString()}] ${msg}`];
+      return next.length > MAX_LOGS ? next.slice(-MAX_LOGS) : next;
+    });
   };
 
   // Poll status
@@ -190,7 +194,7 @@ export default function AutoTagPage() {
     try {
       wsRef.current = datasetAPI.connectTaggingLogs(
         jobId,
-        (data) => { if (data.log) setLogs(prev => [...prev, data.log as string]); },
+        (data) => { if (data.log) setLogs(prev => { const next = [...prev, data.log as string]; return next.length > MAX_LOGS ? next.slice(-MAX_LOGS) : next; }); },
         (error) => {
           console.error('WebSocket error:', error);
           addLog('⚠️ Log connection lost - using status polling');
@@ -297,7 +301,7 @@ export default function AutoTagPage() {
           if (wsRef.current) wsRef.current.close();
           wsRef.current = captioningAPI.connectLogs(
             response.job_id,
-            (data) => { if (data.log) setLogs(prev => [...prev, data.log as string]); },
+            (data) => { if (data.log) setLogs(prev => { const next = [...prev, data.log as string]; return next.length > MAX_LOGS ? next.slice(-MAX_LOGS) : next; }); },
             (error) => {
               console.error('WebSocket error:', error);
               addLog('⚠️ Log connection lost - using status polling');

--- a/frontend/app/dataset/[name]/tags/page.tsx
+++ b/frontend/app/dataset/[name]/tags/page.tsx
@@ -372,6 +372,8 @@ export default function DatasetTagsPage() {
                   src={img.url || `/api/files/image/${datasetName}/${img.image_name}`}
                   alt={img.image_name}
                   className="h-full w-full rounded-t-lg object-contain"
+                  loading="lazy"
+                  decoding="async"
                   onError={(e) => (e.currentTarget.src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="200" height="200"%3E%3Crect width="200" height="200" fill="%23333"/%3E%3Ctext x="50%25" y="50%25" dominant-baseline="middle" text-anchor="middle" fill="%23999" font-family="sans-serif"%3ENo Image%3C/text%3E%3C/svg%3E')}
                 />
               </AspectRatio>

--- a/frontend/components/DatasetUploader.tsx
+++ b/frontend/components/DatasetUploader.tsx
@@ -25,6 +25,7 @@ interface UploadedFile {
   status: 'pending' | 'uploading' | 'success' | 'error';
   progress: number;
   error?: string;
+  preview?: string; // Blob URL for image preview (revoked on cleanup)
 }
 
 export default function DatasetUploader() {
@@ -91,6 +92,7 @@ export default function DatasetUploader() {
       file,
       status: 'pending',
       progress: 0,
+      preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined,
     }));
 
     setFiles((prev) => [...prev, ...newFiles]);
@@ -243,6 +245,7 @@ export default function DatasetUploader() {
       if (result.success) {
         console.log(`✅ Extracted ${result.extracted} images`);
         alert(`✅ ZIP uploaded! Extracted ${result.extracted} images.\n${result.errors.length > 0 ? `Errors:\n${result.errors.join('\n')}` : ''}`);
+        revokePreviewUrls(files);
         setFiles([]);
 
         // Reload existing datasets list
@@ -268,13 +271,28 @@ export default function DatasetUploader() {
     }
   };
 
+  // Revoke blob URLs to prevent memory leaks
+  const revokePreviewUrls = useCallback((filesToRevoke: UploadedFile[]) => {
+    filesToRevoke.forEach(f => {
+      if (f.preview) URL.revokeObjectURL(f.preview);
+    });
+  }, []);
+
+  // Revoke blob URLs on unmount
+  useEffect(() => {
+    return () => revokePreviewUrls(files);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Clear files
   const handleClear = () => {
+    revokePreviewUrls(files);
     setFiles([]);
   };
 
   // Reset upload state
   const handleReset = () => {
+    revokePreviewUrls(files);
     setFiles([]);
     setUploading(false);
   };
@@ -538,7 +556,6 @@ export default function DatasetUploader() {
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 max-h-96 overflow-y-auto p-1">
                 {files.map((fileObj, index) => {
                   const isZip = fileObj.file.name.endsWith('.zip');
-                  const preview = !isZip ? URL.createObjectURL(fileObj.file) : null;
 
                   return (
                     <div
@@ -552,9 +569,10 @@ export default function DatasetUploader() {
                         </div>
                       ) : (
                         <img
-                          src={preview!}
+                          src={fileObj.preview}
                           alt={fileObj.file.name}
                           className="w-full h-32 object-cover"
+                          loading="lazy"
                         />
                       )}
 

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -35,6 +35,7 @@ export default function TrainingMonitor() {
 
   const wsRef = useRef<WebSocket | null>(null);
   const logsEndRef = useRef<HTMLDivElement>(null);
+  const MAX_LOGS = 1000;
 
   // Auto-scroll logs to bottom
   const scrollToBottom = () => {
@@ -132,7 +133,10 @@ export default function TrainingMonitor() {
       jobId,
       (data) => {
         if (data.type === 'log') {
-          setLogs((prev) => [...prev, data.message as string]);
+          setLogs((prev) => {
+            const next = [...prev, data.message as string];
+            return next.length > MAX_LOGS ? next.slice(-MAX_LOGS) : next;
+          });
         } else if (data.type === 'progress') {
           setStatus((prev) => ({
             ...prev,

--- a/frontend/lib/node-services/tagging-service.ts
+++ b/frontend/lib/node-services/tagging-service.ts
@@ -102,10 +102,20 @@ class TaggingService {
 
     console.log(`[Tagging] Loading model: ${modelName}`);
 
-    // Load ONNX Model (CPU execution - no CUDA needed!)
-    this.session = await ort.InferenceSession.create(modelFile, {
-      executionProviders: ['cpu'],
-    });
+    // Load ONNX Model - try GPU first, fall back to CPU
+    // onnxruntime-node supports CUDA on x64 Linux (VastAI GPU instances)
+    try {
+      this.session = await ort.InferenceSession.create(modelFile, {
+        executionProviders: ['cuda', 'cpu'],
+      });
+      console.log(`[Tagging] Model loaded with GPU (CUDA) acceleration`);
+    } catch {
+      // CUDA not available - fall back to CPU only
+      console.log(`[Tagging] CUDA not available, falling back to CPU`);
+      this.session = await ort.InferenceSession.create(modelFile, {
+        executionProviders: ['cpu'],
+      });
+    }
 
     // Load Tags CSV
     const csvContent = await fs.readFile(csvFile, 'utf-8');


### PR DESCRIPTION
- DatasetUploader: Fix blob URL leak - createObjectURL was called every render and never revoked. Now created once in onDrop, revoked on clear/reset/unmount.
- Tag editor: Add loading="lazy" + decoding="async" to images so browser doesn't load entire dataset at once.
- Auto-tag page: Cap logs array at 500 entries to prevent unbounded growth in all 3 log sources (addLog, WD14 WS, BLIP/GIT WS).
- TrainingMonitor: Cap logs at 1000 entries.
- Tagging service: Try CUDA execution provider with CPU fallback. NOTE: onnxruntime-node is CPU-only (see #150 for GPU fix plan).