### PR TITLE
fix: wire training monitor to Python backend endpoints

### DIFF
--- a/api/routes/training.py
+++ b/api/routes/training.py
@@ -262,6 +262,58 @@ async def get_training_status(job_id: str):
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/logs/{job_id}")
+async def get_training_logs(job_id: str, since: int = 0, limit: int = 0):
+    """
+    Get training logs via HTTP (works through reverse proxies).
+
+    Query params:
+        since: line index to start from (0-based) - returns logs after this index
+        limit: max number of log lines to return (0 = no limit)
+    """
+    try:
+        from services.jobs import job_manager as py_job_manager
+
+        job = py_job_manager.store.get(job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+        # Get logs from the requested position
+        logs = job.get_logs(since)
+
+        # Apply limit if specified
+        if limit > 0:
+            logs = logs[-limit:]
+
+        # Format logs to match the Node.js /api/jobs/[id]/logs response format
+        import time
+        formatted_logs = [
+            {
+                "timestamp": int(time.time() * 1000),  # ms timestamp
+                "level": "info",
+                "message": line,
+                "raw": line,
+            }
+            for line in logs
+        ]
+
+        return {
+            "success": True,
+            "job_id": job_id,
+            "logs": formatted_logs,
+            "total_logs": len(job.logs),
+            "status": job.status.value,
+            "progress": job.progress,
+            "next_since": since + len(logs),  # client sends this as next 'since'
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to get training logs: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.post("/stop/{job_id}")
 async def stop_training(job_id: str):
     """Stop a running training job"""

--- a/frontend/components/training/TrainingConfig.tsx
+++ b/frontend/components/training/TrainingConfig.tsx
@@ -97,6 +97,13 @@ export default function TrainingConfigNew() {
       const response = await trainingAPI.start(validatedConfig);
       if (response.success) {
         setTrainingJobId(response.job_id || null);
+        // Store job ID for TrainingMonitor to pick up
+        if (response.job_id && typeof window !== 'undefined') {
+          localStorage.setItem('current_training_job_id', response.job_id);
+          window.dispatchEvent(new CustomEvent('training-started', {
+            detail: { jobId: response.job_id },
+          }));
+        }
         alert(`✅ Training started! Job ID: ${response.job_id}`);
       } else {
         alert(`❌ Training failed: ${response.message}`);

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -13,6 +13,7 @@ interface TrainingStatus {
     total_epochs?: number;
     loss?: number;
     lr?: number;
+    progress_percent?: number;  // 0-100 from Python backend
   };
 }
 
@@ -144,7 +145,10 @@ export default function TrainingMonitor() {
         } else if (data.type === 'progress' && data.progress !== undefined) {
           setStatus((prev) => ({
             ...prev,
-            progress: data.progress as any,
+            progress: {
+              ...prev.progress,
+              progress_percent: data.progress as number,
+            },
           }));
         } else if (data.type === 'status') {
           if (data.status === 'completed') {
@@ -174,6 +178,9 @@ export default function TrainingMonitor() {
 
   const getProgress = () => {
     if (!status.progress) return 0;
+    // Use progress_percent from Python backend if available
+    if (status.progress.progress_percent !== undefined) return status.progress.progress_percent;
+    // Fallback: calculate from step/total
     const { current_step, total_steps } = status.progress;
     if (!current_step || !total_steps) return 0;
     return (current_step / total_steps) * 100;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -754,21 +754,32 @@ export const trainingAPI = {
     return handleResponse(response);
   },
 
-  // ✅ MIGRATED: Uses Node.js /api/jobs/[id]/stop endpoint
+  // Uses Python /api/training/stop/{job_id} endpoint
   stop: async (jobId: string) => {
-    const response = await fetch(`${API_BASE}/jobs/${jobId}/stop`, {
+    const response = await fetch(`${API_BASE}/training/stop/${jobId}`, {
       method: 'POST',
     });
     return handleResponse(response);
   },
 
-  // ✅ MIGRATED: Uses Node.js /api/jobs/[id] endpoint
+  // Uses Python /api/training/status/{job_id} endpoint
+  // Transforms flat Python response to match TrainingMonitor's expected shape
   status: async (jobId: string) => {
-    const response = await fetch(`${API_BASE}/jobs/${jobId}`);
-    return handleResponse(response);
+    const response = await fetch(`${API_BASE}/training/status/${jobId}`);
+    const data = await handleResponse(response);
+    return {
+      is_training: data.status === 'running',
+      job_id: data.job_id,
+      status: data.status,
+      error: data.error,
+      progress: {
+        current_epoch: data.current_epoch,
+        total_epochs: data.total_epochs,
+        progress_percent: data.progress,  // 0-100 from Python
+      },
+    };
   },
 
-  // NOTE: Validation still uses Python backend for now
   validate: async (config: TrainingConfig) => {
     const response = await fetch(`${API_BASE}/training/validate`, {
       method: 'POST',
@@ -778,27 +789,73 @@ export const trainingAPI = {
     return handleResponse(response);
   },
 
-  // HTTP polling for training logs (replaces WebSocket which breaks through Caddy)
+  // HTTP polling for training logs from Python backend
+  // Python uses line-index-based pagination (since=lineNumber), not timestamps
   pollLogs: (
     jobId: string,
     onMessage: (data: WebSocketLogMessage) => void,
     onError?: (error: Error) => void,
   ): LogPoller => {
-    return pollJobLogs(
-      jobId,
-      (logs) => {
-        for (const log of logs) {
-          onMessage({ type: 'log', log: log as any });
+    let nextSince = 0;
+    let stopped = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      if (stopped) return;
+
+      try {
+        const url = `${API_BASE}/training/logs/${jobId}?since=${nextSince}`;
+        const response = await fetch(url);
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
         }
-      },
-      (status, progress) => {
-        if (progress !== undefined) {
-          onMessage({ type: 'progress', progress });
+
+        const data = await response.json();
+
+        if (stopped) return;
+
+        // Deliver new logs
+        if (data.logs && data.logs.length > 0) {
+          for (const log of data.logs) {
+            onMessage({ type: 'log', log: log as any });
+          }
+          // Use server's next_since for line-based pagination
+          nextSince = data.next_since ?? (nextSince + data.logs.length);
         }
-        onMessage({ type: 'status', status });
+
+        // Report status and progress
+        if (data.status) {
+          if (data.progress !== undefined) {
+            onMessage({ type: 'progress', progress: data.progress });
+          }
+          onMessage({ type: 'status', status: data.status });
+        }
+
+        // Stop polling if job is done
+        if (data.status === 'completed' || data.status === 'failed' || data.status === 'cancelled') {
+          stopped = true;
+          return;
+        }
+      } catch (err) {
+        if (!stopped && onError) {
+          onError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+
+      if (!stopped) {
+        timeoutId = setTimeout(poll, 1000);
+      }
+    };
+
+    poll();
+
+    return {
+      stop: () => {
+        stopped = true;
+        if (timeoutId) clearTimeout(timeoutId);
       },
-      onError,
-    );
+    };
   },
 };
 

--- a/services/core/log_parser.py
+++ b/services/core/log_parser.py
@@ -168,6 +168,17 @@ class LogParser:
 
         return progress if found_anything else None
 
+    # Lines that match error keywords but are NOT actual errors
+    ERROR_FALSE_POSITIVES = re.compile(
+        r'mean ar error|'          # Kohya aspect ratio stats
+        r'error \(without|'        # Kohya AR stats variant
+        r'error count|'            # Stats/counters
+        r'error_rate|'             # Metric names
+        r'validation.*error|'      # "validation error rate: 0.0"
+        r'no error',               # "no error found"
+        re.I
+    )
+
     @classmethod
     def extract_error(cls, log_line: str) -> Optional[str]:
         """
@@ -179,6 +190,16 @@ class LogParser:
         Returns:
             Error message if found, None otherwise
         """
+        lower_line = log_line.lower().strip()
+
+        # Skip known false positives first
+        if cls.ERROR_FALSE_POSITIVES.search(lower_line):
+            return None
+
+        # Skip standard INFO/DEBUG log level prefixes
+        if lower_line.startswith(('info', 'debug', 'warning')):
+            return None
+
         error_indicators = [
             'error',
             'exception',
@@ -187,7 +208,6 @@ class LogParser:
             'fatal',
         ]
 
-        lower_line = log_line.lower()
         for indicator in error_indicators:
             if indicator in lower_line:
                 return log_line.strip()


### PR DESCRIPTION
Training jobs live in Python's job manager, but the frontend was polling Node.js endpoints (/api/jobs/{id}) which don't know about training jobs.

- Add GET /api/training/logs/{job_id} Python endpoint for HTTP log polling
- Fix trainingAPI.status() to use /api/training/status/{job_id}
- Fix trainingAPI.stop() to use /api/training/stop/{job_id}
- Add training-specific pollLogs using line-index pagination
- Transform Python's flat status response to TrainingMonitor's shape
- Fix TrainingConfig to emit training-started event + localStorage
- Fix log_parser false positives ("mean ar error" is not an error)