### PR TITLE
fix: resolve CAME optimizer import for Kohya training

### DIFF
--- a/services/trainers/kohya.py
+++ b/services/trainers/kohya.py
@@ -98,13 +98,20 @@ class KohyaTrainer(BaseTrainer):
 
         # 6. Execute Async Process (The Fix)
         try:
+            # Build env with derrian_backend on PYTHONPATH so custom optimizers
+            # (CAME, Compass, etc.) are importable from the sd_scripts cwd
+            env = os.environ.copy()
+            derrian_dir = str(self.sd_scripts_dir.parent)  # trainer/derrian_backend
+            existing_pythonpath = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = f"{derrian_dir}:{existing_pythonpath}" if existing_pythonpath else derrian_dir
+
             process = await asyncio.create_subprocess_exec(
                 cmd[0],  # Program (python)
                 *cmd[1:],  # Arguments
                 cwd=self.sd_scripts_dir,
                 stdout=asyncio.subprocess.PIPE,  # Capture stdout
                 stderr=asyncio.subprocess.STDOUT,  # Merge stderr into stdout (Critical so errors show in logs)
-                env=os.environ.copy(),
+                env=env,
             )
             return process  # Now returns an asyncio Process compatible with JobManager
 

--- a/services/trainers/kohya_toml.py
+++ b/services/trainers/kohya_toml.py
@@ -212,6 +212,22 @@ class KohyaTOMLGenerator:
 
         logger.info("Generated main config TOML: %s", output_path)
 
+    # Optimizers that aren't in torch.optim need full dotted module paths
+    # so Kohya's train_util.py can import them via importlib
+    CUSTOM_OPTIMIZER_PATHS = {
+        "CAME": "custom_scheduler.LoraEasyCustomOptimizer.CAME",
+    }
+
+    def _resolve_optimizer_type(self, optimizer_type: str) -> str:
+        """
+        Map friendly optimizer names to importable module paths.
+
+        Kohya's train_util.py checks: if "." not in name → torch.optim lookup.
+        If "." in name → importlib.import_module. Custom optimizers need the
+        full dotted path to their vendored location.
+        """
+        return self.CUSTOM_OPTIMIZER_PATHS.get(optimizer_type, optimizer_type)
+
     def _get_network_config(self) -> Dict[str, Any]:
         """
         Helper to determine module string based on LoRA type.
@@ -279,7 +295,7 @@ class KohyaTOMLGenerator:
             "lr_warmup_ratio": self.config.lr_warmup_ratio,
             "lr_warmup_steps": self.config.lr_warmup_steps,
             "lr_power": self.config.lr_power,
-            "optimizer_type": self.config.optimizer_type,
+            "optimizer_type": self._resolve_optimizer_type(self.config.optimizer_type),
             "max_grad_norm": self.config.max_grad_norm,
             "weight_decay": self.config.weight_decay,
             "max_token_length": self.config.max_token_length,


### PR DESCRIPTION
Kohya's train_util.py uses importlib for non-torch.optim optimizers: if name has no "." → torch.optim lookup (fails for CAME). if name has "." → importlib from dotted path.

- Map "CAME" to "custom_scheduler.LoraEasyCustomOptimizer.CAME" in TOML
- Add trainer/derrian_backend to PYTHONPATH so custom_scheduler is importable from the sd_scripts working directory