### PR TITLE
fix: correct custom optimizer import paths to match

### DIFF
--- a/services/trainers/kohya_toml.py
+++ b/services/trainers/kohya_toml.py
@@ -214,8 +214,16 @@ class KohyaTOMLGenerator:
 
     # Optimizers that aren't in torch.optim need full dotted module paths
     # so Kohya's train_util.py can import them via importlib
+    # Dotted import paths for custom optimizers.
+    # LoraEasyCustomOptimizer is pip-installed as a package by installer.py
+    # (via `pip install -e .` on trainer/derrian_backend/custom_scheduler/),
+    # so the import root is the package name, NOT the directory path.
+    # Original paths from derrian's utils/validation.py.
     CUSTOM_OPTIMIZER_PATHS = {
-        "CAME": "custom_scheduler.LoraEasyCustomOptimizer.CAME",
+        "CAME": "LoraEasyCustomOptimizer.came.CAME",
+        "Compass": "LoraEasyCustomOptimizer.compass.Compass",
+        "LPFAdamW": "LoraEasyCustomOptimizer.lpfadamw.LPFAdamW",
+        "RMSProp": "LoraEasyCustomOptimizer.rmsprop.RMSProp",
     }
 
     def _resolve_optimizer_type(self, optimizer_type: str) -> str:


### PR DESCRIPTION
correct custom optimizer import paths to match pip-installed package

The optimizer paths used filesystem paths (custom_scheduler.LoraEasyCustomOptimizer.CAME) but the package is pip-installed by installer.py, so the correct import path starts at the package name (LoraEasyCustomOptimizer.came.CAME) - matching derrian's original validation.py.

Also adds Compass, LPFAdamW, and RMSProp mappings.