### PR TITLE
fix: form state management - hydration race, auto-save, stale jobs

### DIFF
--- a/frontend/components/training/TrainingConfig.tsx
+++ b/frontend/components/training/TrainingConfig.tsx
@@ -38,6 +38,7 @@ export default function TrainingConfigNew() {
     config,
     isDirty,
     isValid,
+    isHydrated,
     syncToStore,
     loadPreset,
     getValidationErrors,
@@ -49,7 +50,11 @@ export default function TrainingConfigNew() {
     validateOnChange: true,
   });
 
+  // Fetch dropdown options AFTER hydration completes
   useEffect(() => {
+    // Wait for localStorage hydration before fetching options
+    if (!isHydrated) return;
+
     const fetchOptions = async () => {
       try {
         const workspaceRes = await fetch('/api/files/default-workspace');
@@ -72,7 +77,7 @@ export default function TrainingConfigNew() {
         const datasetsData = datasetsRes.ok ? await datasetsRes.json() : { files: [] };
         setDatasets((datasetsData.files || []).filter((f: any) => f.type === 'dir').map((dir: any) => ({ value: dir.path, label: dir.name })));
 
-        // Set defaults ONCE
+        // Set defaults ONLY for truly empty fields (not overwriting hydrated values)
         if (!hasInitialized.current) {
             if (!form.getValues('output_dir')) form.setValue('output_dir', `${root}/output`);
             if (!form.getValues('pretrained_model_name_or_path') && modelsData.models?.length > 0) {
@@ -89,7 +94,8 @@ export default function TrainingConfigNew() {
       }
     };
     fetchOptions();
-  }, [form]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHydrated]);
 
   const startTraining = async (validatedConfig: any) => {
     try {

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -56,9 +56,16 @@ export default function TrainingMonitor() {
       try {
         const statusData = await trainingAPI.status(currentJobId);
         setStatus(statusData);
+
+        // If job is done (completed/failed/cancelled), clear stale ID
+        if (!statusData.is_training) {
+          localStorage.removeItem('current_training_job_id');
+        }
       } catch (err) {
-        // No training running - stay idle
+        // Job not found (e.g. backend restarted) - clear stale job ID
         setStatus({ is_training: false });
+        localStorage.removeItem('current_training_job_id');
+        setJobId(null);
       }
     };
 

--- a/frontend/components/training/fields/FormFields.tsx
+++ b/frontend/components/training/fields/FormFields.tsx
@@ -159,7 +159,10 @@ export function SelectFormField<T extends FieldValues>({
           <FormLabel>{label}</FormLabel>
           <Select
             value={field.value}
-            onValueChange={field.onChange} // RHF handles the rest
+            onValueChange={(val: string) => {
+              field.onChange(val);
+              form.setValue(name, val, { shouldDirty: true });
+            }}
           >
             <FormControl><SelectTrigger><SelectValue /></SelectTrigger></FormControl>
             <SelectContent>
@@ -323,7 +326,10 @@ export function ComboboxFormField<T extends FieldValues>({
           <FormLabel>{label}</FormLabel>
           <Combobox
             value={field.value}
-            onValueChange={field.onChange} // Let RHF handle the state
+            onValueChange={(val: string) => {
+              field.onChange(val);
+              form.setValue(name, val, { shouldDirty: true });
+            }}
           >
             <ComboboxAnchor>
               <FormControl><ComboboxInput placeholder={placeholder} /></FormControl>

--- a/frontend/hooks/useTrainingForm.ts
+++ b/frontend/hooks/useTrainingForm.ts
@@ -11,7 +11,13 @@ import { useTrainingStore } from '@/store/trainingStore';
 import { TrainingConfigSchema } from '@/lib/validation';
 import type { TrainingConfig } from '@/lib/api';
 
-export function useTrainingForm(options: any = {}) {
+export function useTrainingForm(options: {
+  autoSave?: boolean;
+  autoSaveDelay?: number;
+  validateOnChange?: boolean;
+} = {}) {
+  const { autoSave = false, autoSaveDelay = 500 } = options;
+
   const zustandConfig = useTrainingStore((state) => state.config);
   const updateZustandStore = useTrainingStore((state) => state.updateConfig);
   const loadZustandConfig = useTrainingStore((state) => state.loadConfig);
@@ -38,8 +44,37 @@ export function useTrainingForm(options: any = {}) {
         try {
           const { state } = JSON.parse(stored);
           if (state?.config) {
-            formRef.current.reset(state.config, { keepDefaultValues: false });
-            console.log('✅ Hydrated form from localStorage:', state.config.project_name);
+            // Coerce numeric fields that may have been saved as strings
+            const config = { ...state.config };
+            const numericFields = [
+              'unet_lr', 'text_encoder_lr', 'lr_warmup_ratio', 'lr_power',
+              'network_dropout', 'rank_dropout', 'module_dropout', 'weight_decay',
+              'max_grad_norm', 'caption_dropout_rate', 'caption_tag_dropout_rate',
+              'noise_offset', 'adaptive_noise_scale', 'ip_noise_gamma',
+              'multires_noise_discount', 'guidance_scale', 'sigmoid_scale',
+            ];
+            for (const field of numericFields) {
+              if (field in config && typeof config[field] === 'string') {
+                config[field] = Number(config[field]) || 0;
+              }
+            }
+            const intFields = [
+              'resolution', 'num_repeats', 'max_train_epochs', 'max_train_steps',
+              'train_batch_size', 'seed', 'network_dim', 'network_alpha',
+              'conv_dim', 'conv_alpha', 'gradient_accumulation_steps',
+              'keep_tokens', 'clip_skip', 'max_token_length', 'lr_scheduler_number',
+              'lr_warmup_steps', 'save_every_n_epochs', 'save_every_n_steps',
+              'min_bucket_reso', 'max_bucket_reso', 'bucket_reso_steps',
+              'vae_batch_size', 'factor',
+            ];
+            for (const field of intFields) {
+              if (field in config && typeof config[field] === 'string') {
+                config[field] = parseInt(config[field], 10) || 0;
+              }
+            }
+
+            formRef.current.reset(config, { keepDefaultValues: false });
+            console.log('Hydrated form from localStorage:', config.project_name);
           }
         } catch (e) {
           console.error('Failed to hydrate from localStorage:', e);
@@ -51,11 +86,30 @@ export function useTrainingForm(options: any = {}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setHasHydrated]); // Only run once
 
-  // ✅ INTENTIONAL SYNC: Call this to push current form data to Zustand
+  // Auto-save: watch form changes and sync to Zustand with debounce
+  useEffect(() => {
+    if (!autoSave) return;
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const subscription = form.watch(() => {
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        const values = form.getValues();
+        updateZustandStore(values);
+      }, autoSaveDelay);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [autoSave, autoSaveDelay, form, updateZustandStore]);
+
+  // Sync: push current form data to Zustand
   const syncToStore = useCallback(() => {
     const values = form.getValues();
     updateZustandStore(values);
-    console.log("🛰️ Form synced to Zustand for project:", values.project_name);
+    console.log("Form synced to Zustand for project:", values.project_name);
   }, [form, updateZustandStore]);
 
   const loadPreset = useCallback((preset: Partial<TrainingConfig>) => {
@@ -106,10 +160,11 @@ export function useTrainingForm(options: any = {}) {
     config: zustandConfig,
     isDirty: form.formState.isDirty,
     isValid: form.formState.isValid,
-    syncToStore, // ✅ Give the UI the ability to save manually
+    isHydrated: hasHydrated,
+    syncToStore,
     loadPreset,
     onSubmit,
-    getValidationErrors, // 👈 ADD THIS LINE
+    getValidationErrors,
     resetForm: () => form.reset(zustandConfig),
   };
 }

--- a/services/models/training.py
+++ b/services/models/training.py
@@ -135,7 +135,7 @@ class TrainingConfig(BaseModel):
 
     # ========== LEARNING RATES ==========
     unet_lr: float = Field(1e-4, gt=0, description="UNet learning rate")
-    text_encoder_lr: float = Field(1e-5, gt=0, description="Text encoder learning rate")
+    text_encoder_lr: float = Field(1e-5, ge=0, description="Text encoder learning rate (0 = freeze)")
     lr_scheduler: LRScheduler = Field(LRScheduler.COSINE, description="LR scheduler type")
     lr_scheduler_number: int = Field(1, ge=0, description="Scheduler-specific parameter")
     lr_warmup_ratio: float = Field(0.0, ge=0.0, le=1.0, description="Warmup ratio")


### PR DESCRIPTION
- Coerce numeric fields from strings on localStorage hydration (prevents "not a valid number" validation errors from stale stored values)
- Implement actual auto-save: debounced form.watch() syncs to Zustand (was passed as option but completely ignored)
- Fix fetchOptions race condition: wait for hydration before populating dropdowns, preventing saved values from being overwritten with defaults
- Fix SelectFormField and ComboboxFormField to call form.setValue() with shouldDirty so changes propagate to Zustand store
- Clear stale job ID from localStorage when backend returns 404 (after restart) or when job is completed/failed
- Allow text_encoder_lr=0 in Python validation (gt=0 -> ge=0) for freezing text encoder