### PR TITLE
Fix/vastai frontend binding 112

### DIFF
--- a/frontend/app/api/jobs/tagging/route.ts
+++ b/frontend/app/api/jobs/tagging/route.ts
@@ -1,72 +1,39 @@
 /**
  * Next.js API Routes: /api/jobs/tagging
- * Create tagging jobs via the tagging orchestrator.
+ * Proxies tagging requests to the FastAPI backend which handles
+ * WD14 tagging with GPU-accelerated onnxruntime.
  *
  * POST - Start a new WD14 tagging job
- *
- * The orchestrator automatically selects the best backend:
- * - Python (GPU-accelerated via onnxruntime-gpu) if available
- * - Node.js ONNX Runtime (CPU fallback) otherwise
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import {
-  startTagging,
-  type TaggingRequest,
-} from '@/lib/node-services/tagging-orchestrator';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
 /**
  * POST /api/jobs/tagging
- * Start a new WD14 tagging job
+ * Proxy to FastAPI backend's /api/dataset/tag endpoint
  */
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    // Validate required fields
-    if (!body.dataset_dir) {
+    const response = await fetch(`${BACKEND_URL}/api/dataset/tag`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
       return NextResponse.json(
-        { success: false, error: 'Missing required field: dataset_dir' },
-        { status: 400 }
+        { success: false, error: data.detail || `Backend error: ${response.status}` },
+        { status: response.status }
       );
     }
 
-    // Build request with defaults
-    const taggingRequest: TaggingRequest = {
-      dataset_dir: body.dataset_dir,
-      model: body.model || 'SmilingWolf/wd-vit-large-tagger-v3',
-      threshold: body.threshold ?? 0.35,
-      general_threshold: body.general_threshold,
-      character_threshold: body.character_threshold,
-      caption_extension: body.caption_extension || '.txt',
-      batch_size: body.batch_size,
-      caption_separator: body.caption_separator || ', ',
-      undesired_tags: body.undesired_tags || '',
-      remove_underscore: body.remove_underscore ?? true,
-      character_tags_first: body.character_tags_first ?? false,
-      always_first_tags: body.always_first_tags,
-      append_tags: body.append_tags ?? false,
-      recursive: body.recursive ?? false,
-      use_rating_tags: body.use_rating_tags ?? false,
-      use_rating_tags_as_last_tag: body.use_rating_tags_as_last_tag ?? false,
-      tag_replacement: body.tag_replacement,
-      character_tag_expand: body.character_tag_expand ?? false,
-      force_prepend_trigger: body.force_prepend_trigger ?? true,
-    };
-
-    const { jobId, backend } = await startTagging(taggingRequest);
-
-    const backendLabel =
-      backend === 'python'
-        ? 'Python onnxruntime (GPU-accelerated)'
-        : 'Node.js ONNX Runtime (CPU)';
-
-    return NextResponse.json({
-      success: true,
-      job_id: jobId,
-      backend,
-      message: `Tagging job started (${backendLabel})`,
-    });
+    return NextResponse.json(data);
   } catch (error) {
     return NextResponse.json(
       {

--- a/provision_runpod.sh
+++ b/provision_runpod.sh
@@ -109,16 +109,15 @@ provisioning_start() {
         done
 
         if [ "$NODE_FOUND" = false ]; then
-            echo "  Node.js not found - installing via nvm..."
-            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-            export NVM_DIR="$HOME/.nvm"
-            # shellcheck disable=SC1091
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm install 20
-            nvm use 20
+            echo "  Node.js not found - installing system-wide..."
+            # Install directly to /usr/local so it's always in PATH (survives restarts)
+            NODE_VERSION="v20.18.1"
+            curl -fsSL "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz" | tar -xJ -C /usr/local --strip-components=1
             if ! command -v node &> /dev/null; then
                 echo "  Node.js installation failed! Frontend will be unavailable."
                 SKIP_FRONTEND=true
+            else
+                echo "  Installed Node.js $(node --version) to /usr/local/bin"
             fi
         fi
     fi


### PR DESCRIPTION
  1. Node.js install — now uses direct binary tarball to /usr/local/bin instead of nvm. No shell config needed, survives   restarts.
  2. Build error — tagging-orchestrator.ts never existed. Replaced the route with a simple proxy to the FastAPI backend   (which already does GPU-accelerated tagging via Python).
  3. Fix Provisioning for Runpod