### PR TITLE
fix: Upgrade onnxruntime-gpu to >=1.19 for cuDNN 9 support (#229)

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -272,7 +272,31 @@ class RemoteInstaller:
         install_cmd = self.get_install_command("-r", requirements_file)
         success = self.run_command(install_cmd, f"Installing Python packages with {self.package_manager['name']}")
 
+        if success:
+            self.verify_onnx_runtime()
+
         return success
+
+    def verify_onnx_runtime(self):
+        """Verify ONNX runtime is installed and can see GPU providers."""
+        self.logger.info("Verifying ONNX runtime installation...")
+        print("Verifying ONNX runtime installation...")
+
+        verify_cmd = [
+            self.python_cmd,
+            "-c",
+            "import onnxruntime as ort; print(f'ONNX Runtime {ort.__version__} — Providers: {ort.get_available_providers()}')"
+        ]
+
+        success = self.run_command(verify_cmd, "Verifying ONNX runtime import")
+
+        if success:
+            self.logger.info("ONNX runtime verification successful")
+            print("ONNX runtime verification successful")
+        else:
+            self.logger.error("ONNX runtime verification failed — WD14 tagging may fall back to CPU")
+            print("ONNX runtime verification failed — WD14 tagging may fall back to CPU")
+            print("   If tagging is slow, try: pip install --upgrade onnxruntime-gpu")
 
     def check_system_dependencies(self):
         """Check and attempt to install required system packages like aria2c"""

--- a/provision_runpod.sh
+++ b/provision_runpod.sh
@@ -203,12 +203,11 @@ provisioning_start() {
         echo "  Frontend directory not found - skipping Next.js setup"
     fi
 
-    # Fix onnxruntime-gpu for cuDNN 9 (RunPod base images ship cuDNN 9, but
-    # requirements.txt pins 1.17.1 which needs cuDNN 8). Upgrade to a version
-    # that supports cuDNN 9 + CUDA 12.x.
+    # Verify onnxruntime-gpu can see the GPU (requirements now use >=1.19 which
+    # ships cuDNN 9 support from standard PyPI — no special index needed).
     if ! $PYTHON_CMD -c "import onnxruntime; print(onnxruntime.get_device())" 2>/dev/null | grep -q GPU; then
-        echo "  onnxruntime-gpu doesn't see CUDA — reinstalling for cuDNN 9..."
-        $PYTHON_CMD -m pip install --upgrade onnxruntime-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ --no-cache-dir -q
+        echo "  onnxruntime-gpu doesn't see CUDA — attempting upgrade..."
+        $PYTHON_CMD -m pip install --upgrade onnxruntime-gpu --no-cache-dir -q
     fi
 
     # Configure git for root usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,11 +74,10 @@ watchdog>=4.0.0
 tensorboard
 
 # ONNX / Tagger Dependencies
-# Use Microsoft's CUDA 12 package index for proper GPU support
-# NOTE: --extra-index-url must be on separate line before the package
---extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/
+# onnxruntime-gpu 1.19+ ships with CUDA 12 + cuDNN 9 support on standard PyPI.
+# No extra-index-url needed (removed Microsoft CUDA 12 index — only had cuDNN 8 builds).
 onnx>=1.16.1  # Alerts #62, #64: Can't upgrade to 1.17.0 (needs protobuf 4.x, breaks transformers/diffusers). Low risk: trusted HF models only.
-onnxruntime-gpu==1.17.1
+onnxruntime-gpu>=1.19.0  # Needs >=1.19 for cuDNN 9 support (VastAI/RunPod containers ship cuDNN 9). See issue #229.
 protobuf>=3.20.2,<4  # CVE fixes: alerts #50, #51. Can't use 4.x (breaks ONNX 1.16/transformers/diffusers).
 
 # -- Essential Commented Dependencies (Now Active) --

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -74,11 +74,10 @@ watchdog>=4.0.0
 tensorboard
 
 # ONNX / Tagger Dependencies
-# Use Microsoft's CUDA 12 package index for proper GPU support
-# NOTE: --extra-index-url must be on separate line before the package
---extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/
+# onnxruntime-gpu 1.19+ ships with CUDA 12 + cuDNN 9 support on standard PyPI.
+# No extra-index-url needed (removed Microsoft CUDA 12 index — only had cuDNN 8 builds).
 onnx>=1.16.1  # Alerts #62, #64: Can't upgrade to 1.17.0 (needs protobuf 4.x, breaks transformers/diffusers). Low risk: trusted HF models only.
-onnxruntime-gpu==1.17.1
+onnxruntime-gpu>=1.19.0  # Needs >=1.19 for cuDNN 9 support (VastAI/RunPod containers ship cuDNN 9). See issue #229.
 protobuf>=3.20.2,<4  # CVE fixes: alerts #50, #51. Can't use 4.x (breaks ONNX 1.16/transformers/diffusers).
 
 # -- Essential Commented Dependencies (Now Active) --

--- a/vastai_setup.sh
+++ b/vastai_setup.sh
@@ -185,11 +185,11 @@ provisioning_start() {
         chmod +x start_services_local.sh
     fi
 
-    # Fix onnxruntime-gpu for cuDNN 9 (some VastAI images ship cuDNN 9, but
-    # requirements.txt pins 1.17.1 which needs cuDNN 8).
+    # Verify onnxruntime-gpu can see the GPU (requirements now use >=1.19 which
+    # ships cuDNN 9 support from standard PyPI — no special index needed).
     if ! $PYTHON_CMD -c "import onnxruntime; print(onnxruntime.get_device())" 2>/dev/null | grep -q GPU; then
-        echo "  onnxruntime-gpu doesn't see CUDA — reinstalling for cuDNN 9..."
-        $PYTHON_CMD -m pip install --upgrade onnxruntime-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ --no-cache-dir -q
+        echo "  onnxruntime-gpu doesn't see CUDA — attempting upgrade..."
+        $PYTHON_CMD -m pip install --upgrade onnxruntime-gpu --no-cache-dir -q
     fi
 
     # Configure git for root usage


### PR DESCRIPTION
onnxruntime-gpu 1.17.1 requires cuDNN 8, but VastAI/RunPod containers now ship cuDNN 9. Symlink hacks can't bridge this ABI gap. Upgrading to >=1.19.0 which natively supports CUDA 12 + cuDNN 9 from standard PyPI — no Microsoft extra-index-url needed.

- requirements_base.txt / requirements.txt: onnxruntime-gpu >=1.19.0
- installer.py: restore verify_onnx_runtime() post-install check
- vastai_setup.sh / provision_runpod.sh: simplify fallback upgrade



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ONNX runtime verification to validate installation and display version/provider information.

* **Improvements**
  * Updated ONNX runtime to version 1.19.0+ with enhanced GPU support via standard PyPI.
  * Simplified GPU compatibility detection and upgrade process.
  * Enhanced installation logging and added persistent log directory configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->