### PR TITLE
Pin lodash >=4.18.0 to fix CVE-2026-4800 and CVE-2026-2950

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11897,9 +11897,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,7 +101,8 @@
       "@modelcontextprotocol/sdk": "^1.24.0"
     },
     "flatted": ">=3.4.2",
-    "picomatch": ">=2.3.2"
+    "picomatch": ">=2.3.2",
+    "lodash": ">=4.18.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",


### PR DESCRIPTION
CVE-2026-4800: Code injection via _.template (CVSS 8.1) 
CVE-2026-2950: Prototype pollution bypass in _.unset/_.omit (CVSS 6.5) Both affect lodash <4.18.0 coming in transitively via uppy.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency overrides to enhance compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->