### PR TITLE
Fix DOM password warning on HuggingFace upload page

### DIFF
--- a/frontend/app/huggingface-upload/page.tsx
+++ b/frontend/app/huggingface-upload/page.tsx
@@ -5,6 +5,7 @@ import { utilitiesAPI, LoRAFile } from '@/lib/api';
 import { Upload, FolderOpen, CheckCircle, XCircle, Loader2, Minimize2, Home } from 'lucide-react';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 
 export default function HuggingFaceUploadPage() {
   const [uploadType, setUploadType] = useState<'lora' | 'dataset'>('lora');
@@ -179,11 +180,13 @@ export default function HuggingFaceUploadPage() {
             {/* Token */}
             <div className="mb-4">
               <form onSubmit={(e: FormEvent) => { e.preventDefault(); handleValidateToken(); }} autoComplete="off">
-              <label className="block text-sm font-medium mb-2">
+              <label htmlFor="hf-token" className="block text-sm font-medium mb-2">
                 HuggingFace Token (Write Access) *
               </label>
               <div className="flex gap-2">
                 <Input
+                  id="hf-token"
+                  name="hfToken"
                   type="password"
                   value={hfToken}
                   onChange={(e) => {
@@ -194,12 +197,9 @@ export default function HuggingFaceUploadPage() {
                   className="flex-1"
                   placeholder="hf_..."
                 />
-                <button
-                  type="submit"
-                  className="px-4 py-2 bg-cyan-600 hover:bg-cyan-700 text-white rounded-lg"
-                >
+                <Button type="submit">
                   Validate
-                </button>
+                </Button>
               </div>
               </form>
 

--- a/frontend/app/huggingface-upload/page.tsx
+++ b/frontend/app/huggingface-upload/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, FormEvent } from 'react';
 import { utilitiesAPI, LoRAFile } from '@/lib/api';
 import { Upload, FolderOpen, CheckCircle, XCircle, Loader2, Minimize2, Home } from 'lucide-react';
 import Breadcrumbs from '@/components/Breadcrumbs';
+import { Input } from '@/components/ui/input';
 
 export default function HuggingFaceUploadPage() {
   const [uploadType, setUploadType] = useState<'lora' | 'dataset'>('lora');
@@ -177,27 +178,30 @@ export default function HuggingFaceUploadPage() {
 
             {/* Token */}
             <div className="mb-4">
+              <form onSubmit={(e: FormEvent) => { e.preventDefault(); handleValidateToken(); }} autoComplete="off">
               <label className="block text-sm font-medium mb-2">
                 HuggingFace Token (Write Access) *
               </label>
               <div className="flex gap-2">
-                <input
+                <Input
                   type="password"
                   value={hfToken}
                   onChange={(e) => {
                     setHfToken(e.target.value);
                     setTokenValid(null);
                   }}
-                  className="flex-1 px-3 py-2 bg-input border border-input text-foreground rounded-lg focus:ring-2 focus:ring-cyan-500"
+                  autoComplete="off"
+                  className="flex-1"
                   placeholder="hf_..."
                 />
                 <button
-                  onClick={handleValidateToken}
+                  type="submit"
                   className="px-4 py-2 bg-cyan-600 hover:bg-cyan-700 text-white rounded-lg"
                 >
                   Validate
                 </button>
               </div>
+              </form>
 
               {tokenValid !== null && (
                 <div className={`mt-2 flex items-center gap-2 text-sm ${tokenValid ? 'text-green-600' : 'text-red-600'}`}>


### PR DESCRIPTION
Wrap HF token input in <form> with autoComplete="off" and replace raw <input> with shadcn <Input> component per CLAUDE.md rules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Token validation now uses a form submission flow for a more predictable and intuitive experience; validation triggers on submit.
  * Input and button were replaced with shared UI components to improve accessibility and label association.
* **Style**
  * Simplified input styling and disabled autocomplete for a cleaner, less distracting input experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->