### PR TITLE
fix: remove unused deps that pulled in vulnerable pytest  

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,10 +50,6 @@ huggingface-hub>=0.34.3
 voluptuous>=0.15.2
 sentencepiece>=0.2.1
 wheel
-coverage==7.8.0
-parameterized==0.9.0
-hpsv2==1.2.0
-narwhals==1.34.1
 matplotlib==3.10.1
 
 

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -50,10 +50,6 @@ huggingface-hub>=0.34.3
 voluptuous>=0.15.2
 sentencepiece>=0.2.1
 wheel
-coverage==7.8.0
-parameterized==0.9.0
-hpsv2==1.2.0
-narwhals==1.34.1
 matplotlib==3.10.1
 
 


### PR DESCRIPTION
hpsv2==1.2.0 was never imported anywhere in the codebase but dragged in pytest==7.2.0 as a transitive dependency, triggering Dependabot alert #167 (pytest <9.0.3 vulnerable tmpdir handling, local privilege escalation on UNIX).

Also removes coverage==7.8.0, parameterized==0.9.0, and narwhals==1.34.1 which are equally unused in app code — they belong in the vendored lycoris requirements-dev.txt (where they already live) not in production requirements.

Removes from both requirements.txt and requirements_base.txt.