### PR TITLE
Snyk Supression of Vendored Code Directories

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,6 +4,17 @@
 
 version: v1.25.0
 
+# Exclude vendored third-party code from all Snyk Code (SAST) scans.
+# trainer/derrian_backend/ is a vendored copy of Kohya SS + LyCORIS training
+# scripts. These files are upstream code we do not maintain — any path traversal
+# or injection findings in them reflect patterns that require direct local machine
+# access to exploit (the scripts run as a local subprocess, not a web endpoint).
+# Fixing them would mean diverging from upstream with no real security benefit
+# for a single-user training tool.
+exclude:
+  code:
+    - trainer/derrian_backend/**
+
 ignore:
   SNYK-PYTHON-UNKNOWN-CWE78:
     - installer_windows_local.py:

--- a/.snyk
+++ b/.snyk
@@ -14,3 +14,41 @@ ignore:
           OS-level access. Restructuring the Windows shell=True workaround
           would add complexity for zero real-world risk reduction.
         expires: 2027-01-01T00:00:00.000Z
+
+  SNYK-JS-UNKNOWN-CLEARTEXT:
+    - frontend/server.js:
+        reason: >
+          http.createServer is intentional. TLS termination is handled
+          upstream at the infrastructure layer (VastAI portal proxy,
+          Caddy, or Cloudflare tunnel). The Node.js server only ever
+          listens on localhost/internal interfaces — it is never directly
+          internet-exposed. Requiring users to provision and manage SSL
+          certificates on the application server is inappropriate for a
+          single-user local/VastAI training tool.
+        expires: 2027-01-01T00:00:00.000Z
+
+  SNYK-JS-UNKNOWN-DOMXSS-APPENDCHILD:
+    - frontend/hooks/use-download-file.ts:
+        reason: >
+          appendChild is used to attach a programmatically created <a>
+          element to trigger a file download (standard browser pattern).
+          The href is a blob: URL produced by createObjectURL() which
+          cannot execute scripts. The download attribute is already
+          sanitized to safe characters. No remote HTML content is
+          inserted into the DOM.
+        expires: 2027-01-01T00:00:00.000Z
+
+  SNYK-JS-UNKNOWN-DOMXSS-DANGEROUSLYSETINNERHTML:
+    - frontend/app/docs/page.tsx:
+        reason: >
+          dangerouslySetInnerHTML renders inline markdown (bold/code
+          spans) from hardcoded static strings defined in the component
+          itself. There are no fetch() calls or remote data sources in
+          this file — content cannot be attacker-controlled.
+        expires: 2027-01-01T00:00:00.000Z
+    - frontend/components/effects/glitch-text.tsx:
+        reason: >
+          dangerouslySetInnerHTML injects a <style> block containing
+          CSS keyframe animations. Values are numeric component props
+          (intensity, offset), not user-supplied HTML. No XSS vector exists.
+        expires: 2027-01-01T00:00:00.000Z


### PR DESCRIPTION
[chore: suppress context-blind Snyk false positives in .snyk policy](https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/commit/918c5027425e51b5fb86cb362f569212b0b2a9b4) 

@[duskfallcrew](https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/commits?author=duskfallcrew)
@[claude](https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/commits?author=claude)
duskfallcrew and claude committed 9 minutes ago
[chore: exclude vendored derrian_backend from Snyk Code scans](https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/commit/134acab6ae4bf9af646ca53e6e38e9956adea377) 

@[duskfallcrew](https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/commits?author=duskfallcrew)
@[claude](https://github.com/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/commits?author=claude)
duskfallcrew and claude committed 1 minute ago

These are based off a CWE that the attack vector would apply for MULTI USER setups i.e. Civitai, Fal.ML and other larger things even Huggingface.  KNX Trainer is a SINGULAR instance per user, if we need to deploy it as a larger MULTI user interface we'll make a larger ecosystem for it. 

https://cwe.mitre.org/data/definitions/23.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to exclude vendored dependencies and suppress known security findings in specific files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->