### PR TITLE
fix + feat: VastAI crash fixes, preset visibility, optimizer/scheduler expansion

### DIFF
--- a/api/routes/config.py
+++ b/api/routes/config.py
@@ -151,7 +151,7 @@ async def save_config(request: SaveConfigRequest):
     """
     try:
         import re
-        safe_name = re.sub(r'[^a-zA-Z0-9_\- ]', '_', request.name).strip()
+        safe_name = re.sub(r'[^a-zA-Z0-9_\-]', '_', request.name).strip('_')
         if not safe_name:
             raise HTTPException(status_code=400, detail="Invalid config name")
 

--- a/api/routes/files.py
+++ b/api/routes/files.py
@@ -16,7 +16,7 @@ mimetypes.add_type('image/jxl', '.jxl')
 
 import aiofiles
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -283,10 +283,15 @@ async def download_file(path: str):
         if not file_path.is_file():
             raise HTTPException(status_code=400, detail="Path is not a file")
 
-        return FileResponse(
-            path=file_path,
-            filename=file_path.name,
-            media_type="application/octet-stream"
+        async def _file_chunks():
+            async with aiofiles.open(file_path, "rb") as f:
+                while chunk := await f.read(65536):
+                    yield chunk
+
+        return StreamingResponse(
+            _file_chunks(),
+            media_type="application/octet-stream",
+            headers={"Content-Disposition": f'attachment; filename="{file_path.name}"'},
         )
 
     except HTTPException:

--- a/api/routes/files.py
+++ b/api/routes/files.py
@@ -8,6 +8,7 @@ import mimetypes
 import shutil
 from pathlib import Path
 from typing import List, Literal, Optional
+from urllib.parse import quote
 
 # Ensure WebP and other formats are registered on minimal systems that lack them
 mimetypes.add_type('image/webp', '.webp')
@@ -283,15 +284,31 @@ async def download_file(path: str):
         if not file_path.is_file():
             raise HTTPException(status_code=400, detail="Path is not a file")
 
+        # Snapshot size at request time so active log files don't stream indefinitely
+        snapshot_size = file_path.stat().st_size
+        remaining = snapshot_size
+
         async def _file_chunks():
+            nonlocal remaining
             async with aiofiles.open(file_path, "rb") as f:
-                while chunk := await f.read(65536):
+                while remaining > 0:
+                    chunk = await f.read(min(65536, remaining))
+                    if not chunk:
+                        break
+                    remaining -= len(chunk)
                     yield chunk
+
+        # RFC 5987 encoding so non-ASCII filenames don't raise UnicodeEncodeError
+        fallback_name = "".join(
+            ch if 32 <= ord(ch) < 127 and ch not in {'"', "\\"} else "_"
+            for ch in file_path.name
+        ) or "download"
+        encoded_name = quote(file_path.name, safe="")
 
         return StreamingResponse(
             _file_chunks(),
             media_type="application/octet-stream",
-            headers={"Content-Disposition": f'attachment; filename="{file_path.name}"'},
+            headers={"Content-Disposition": f'attachment; filename="{fallback_name}"; filename*=UTF-8\'\'{encoded_name}'},
         )
 
     except HTTPException:

--- a/frontend/app/api/config/presets/[id]/route.ts
+++ b/frontend/app/api/config/presets/[id]/route.ts
@@ -14,11 +14,15 @@ import { validateConfigPath } from '@/lib/node-services/path-validation';
  * Only allow alphanumeric, hyphens, underscores.
  */
 function sanitizePresetId(id: string): string {
-  const sanitized = id.replace(/[^a-zA-Z0-9_-]/g, '');
-  if (!sanitized) {
+  // Block traversal and directory separator characters; allow spaces/dots that appear in preset filenames
+  if (/[/\\]/.test(id) || id.includes('..')) {
     throw new Error('Invalid preset ID');
   }
-  return sanitized;
+  const trimmed = id.trim();
+  if (!trimmed) {
+    throw new Error('Invalid preset ID');
+  }
+  return trimmed;
 }
 
 export async function GET(
@@ -61,10 +65,22 @@ export async function GET(
     const content = await fs.readFile(filePath, 'utf-8');
     const preset = JSON.parse(content);
 
-    return NextResponse.json({
-      id,
-      ...preset,
-    });
+    // Old community presets (bmaltais GUI format) nest all training keys under a
+    // "config" sub-object with some different key names (e.g. LoRA_type).  Hoist
+    // them to the root so the frontend TrainingConfig fields are populated correctly.
+    let responseData: Record<string, unknown> = { id, ...preset };
+    if (preset.config && typeof preset.config === 'object' && !Array.isArray(preset.config)) {
+      const { config: nestedConfig, ...rest } = preset;
+      const { LoRA_type, ...otherConfig } = nestedConfig as Record<string, unknown>;
+      responseData = {
+        id,
+        ...rest,
+        ...(LoRA_type !== undefined ? { lora_type: LoRA_type } : {}),
+        ...otherConfig,
+      };
+    }
+
+    return NextResponse.json(responseData);
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : String(error) },

--- a/frontend/app/api/config/presets/route.ts
+++ b/frontend/app/api/config/presets/route.ts
@@ -35,7 +35,8 @@ export async function GET(request: NextRequest) {
           name: preset.name || path.parse(file).name,
           description: preset.description || '',
           model_type: preset.model_type,
-          config: preset,
+          created_at: preset.created_at,
+          is_builtin: preset.is_builtin || false,
         });
       } catch (error) {
         console.warn(`Failed to load preset ${file}:`, error);

--- a/frontend/components/training/cards/LearningRateCard.tsx
+++ b/frontend/components/training/cards/LearningRateCard.tsx
@@ -89,6 +89,8 @@ export function LearningRateCard({ form, onSave }: LearningRateCardProps) {
             { value: 'cosine_with_restarts', label: 'Cosine with Restarts', description: 'Periodic resets (best for most)' },
             { value: 'polynomial', label: 'Polynomial', description: 'Polynomial decay' },
             { value: 'adafactor', label: 'AdaFactor', description: 'Adaptive LR (use with AdaFactor optimizer)' },
+            { value: 'rex', label: 'Rex (Warm Restarts)', description: 'Vendored custom scheduler with warm restarts' },
+            { value: 'cosine_annealing', label: 'Cosine Annealing (Warm Restarts)', description: 'Vendored cosine annealing with warm restarts' },
           ]}
         />
 

--- a/frontend/components/training/cards/OptimizerCard.tsx
+++ b/frontend/components/training/cards/OptimizerCard.tsx
@@ -60,6 +60,12 @@ export function OptimizerCard({ form, onSave }: OptimizerCardProps) {
             { value: 'SGDNesterov', label: 'SGDNesterov', description: 'Nesterov SGD' },
             { value: 'SGDNesterov8bit', label: 'SGDNesterov8bit', description: 'Memory-efficient Nesterov' },
             { value: 'CAME', label: 'CAME', description: 'Confidence-guided adaptive (experimental)' },
+            { value: 'Compass', label: 'Compass', description: 'Vendored custom optimizer' },
+            { value: 'LPFAdamW', label: 'LPFAdamW', description: 'Low-pass filtered AdamW' },
+            { value: 'RMSProp', label: 'RMSProp', description: 'Vendored RMSProp' },
+            { value: 'AdamWScheduleFree', label: 'AdamW (Schedule-Free)', description: 'AdamW without LR scheduler' },
+            { value: 'SGDScheduleFree', label: 'SGD (Schedule-Free)', description: 'SGD without LR scheduler' },
+            { value: 'RAdamScheduleFree', label: 'RAdam (Schedule-Free)', description: 'Rectified Adam without LR scheduler' },
           ]}
         />
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -220,8 +220,8 @@ export type LoRAType =
   | 'Diag-OFT'  // Diagonal Orthogonal Finetuning
   | 'BOFT'      // Butterfly OFT
   | 'ABBA';     // Activation-Based Block Adaptation (LyCORIS v3.2.0+)
-export type OptimizerType = 'AdamW' | 'AdamW8bit' | 'Lion' | 'Lion8bit' | 'SGDNesterov' | 'SGDNesterov8bit' | 'DAdaptation' | 'DAdaptAdam' | 'DAdaptAdaGrad' | 'DAdaptAdan' | 'DAdaptSGD' | 'Prodigy' | 'AdaFactor' | 'CAME';
-export type SchedulerType = 'linear' | 'cosine' | 'cosine_with_restarts' | 'polynomial' | 'constant' | 'constant_with_warmup' | 'adafactor';
+export type OptimizerType = 'AdamW' | 'AdamW8bit' | 'Lion' | 'Lion8bit' | 'SGDNesterov' | 'SGDNesterov8bit' | 'DAdaptation' | 'DAdaptAdam' | 'DAdaptAdaGrad' | 'DAdaptAdan' | 'DAdaptSGD' | 'Prodigy' | 'AdaFactor' | 'CAME' | 'Compass' | 'LPFAdamW' | 'RMSProp' | 'AdamWScheduleFree' | 'SGDScheduleFree' | 'RAdamScheduleFree';
+export type SchedulerType = 'linear' | 'cosine' | 'cosine_with_restarts' | 'polynomial' | 'constant' | 'constant_with_warmup' | 'adafactor' | 'rex' | 'cosine_annealing';
 
 export const fileAPI = {
   // ✅ MIGRATED: Uses Node.js /api/files/workspace endpoint

--- a/services/jobs/job_manager.py
+++ b/services/jobs/job_manager.py
@@ -217,6 +217,9 @@ class JobManager:
 
         if job.process:
             try:
+                # Set CANCELLED before terminate so _monitor_job sees the right
+                # status if it processes the process exit before we do.
+                job.status = JobStatusEnum.CANCELLED
                 job.process.terminate()
                 try:
                     await asyncio.wait_for(job.process.wait(), timeout=1.0)
@@ -224,7 +227,6 @@ class JobManager:
                     job.process.kill()
                     await job.process.wait()
 
-                job.status = JobStatusEnum.CANCELLED
                 job.completed_at = datetime.now()
                 logger.info(f"Job {job_id} stopped")
                 return True

--- a/services/jobs/job_manager.py
+++ b/services/jobs/job_manager.py
@@ -142,12 +142,12 @@ class JobManager:
             # Update job status based on exit code
             job.completed_at = datetime.now()
 
-            if returncode == 0:
+            if job.status == JobStatusEnum.CANCELLED:
+                logger.info(f"Job {job_id} process exited after cancellation")
+            elif returncode == 0:
                 job.status = JobStatusEnum.COMPLETED
                 job.progress = 100
                 logger.info(f"Job {job_id} completed successfully")
-            elif job.status == JobStatusEnum.CANCELLED:
-                logger.info(f"Job {job_id} process exited after cancellation")
             else:
                 job.status = JobStatusEnum.FAILED
                 if not job.error:

--- a/services/models/training.py
+++ b/services/models/training.py
@@ -59,6 +59,14 @@ class OptimizerType(str, Enum):
     CAME = "CAME"
     SGDNESTEROV = "SGDNesterov"
     SGDNESTEROV8BIT = "SGDNesterov8bit"
+    # Vendored custom optimizers (LoraEasyCustomOptimizer)
+    COMPASS = "Compass"
+    LPFADAMW = "LPFAdamW"
+    RMSPROP = "RMSProp"
+    # Schedule-free optimizers (schedulefree package)
+    ADAMW_SCHEDULE_FREE = "AdamWScheduleFree"
+    SGD_SCHEDULE_FREE = "SGDScheduleFree"
+    RADAM_SCHEDULE_FREE = "RAdamScheduleFree"
 
 
 class LRScheduler(str, Enum):
@@ -70,6 +78,9 @@ class LRScheduler(str, Enum):
     LINEAR = "linear"
     POLYNOMIAL = "polynomial"
     ADAFACTOR = "adafactor"
+    # Custom schedulers (vendored LoraEasyCustomOptimizer, use lr_scheduler_type)
+    REX = "rex"
+    COSINE_ANNEALING = "cosine_annealing"
 
 
 class MixedPrecision(str, Enum):

--- a/services/trainers/kohya.py
+++ b/services/trainers/kohya.py
@@ -175,7 +175,10 @@ class KohyaTrainer(BaseTrainer):
         # validate_output_path() is designed for filenames, not full directory paths,
         # so we do the containment check inline here.
         try:
-            out_resolved = Path(self.config.output_dir).resolve()
+            out_path = Path(self.config.output_dir)
+            if not out_path.is_absolute():
+                out_path = self.project_root / out_path
+            out_resolved = out_path.resolve()
             allowed = [self.project_root, Path.home()]
             if not any(out_resolved == a or out_resolved.is_relative_to(a) for a in allowed):
                 errors.append(f"Output directory outside allowed paths: {self.config.output_dir}")

--- a/services/trainers/kohya.py
+++ b/services/trainers/kohya.py
@@ -49,6 +49,13 @@ class KohyaTrainer(BaseTrainer):
             config=config, project_root=self.project_root, sd_scripts_dir=self.sd_scripts_dir
         )
 
+    def _resolved_output_dir(self) -> Path:
+        """Resolve output_dir anchored to project_root for relative paths."""
+        p = Path(self.config.output_dir)
+        if not p.is_absolute():
+            p = self.project_root / p
+        return p.resolve()
+
     async def start_training(self):
         """
         Launch Kohya training using AsyncIO (Required for JobManager compatibility).
@@ -87,7 +94,7 @@ class KohyaTrainer(BaseTrainer):
             "--dataset_config",
             str(dataset_toml_user.resolve()),
             "--output_dir",
-            str(Path(self.config.output_dir).resolve()),
+            str(self._resolved_output_dir()),
             "--output_name",
             self.config.project_name,
         ]
@@ -175,10 +182,7 @@ class KohyaTrainer(BaseTrainer):
         # validate_output_path() is designed for filenames, not full directory paths,
         # so we do the containment check inline here.
         try:
-            out_path = Path(self.config.output_dir)
-            if not out_path.is_absolute():
-                out_path = self.project_root / out_path
-            out_resolved = out_path.resolve()
+            out_resolved = self._resolved_output_dir()
             allowed = [self.project_root, Path.home()]
             if not any(out_resolved == a or out_resolved.is_relative_to(a) for a in allowed):
                 errors.append(f"Output directory outside allowed paths: {self.config.output_dir}")
@@ -205,10 +209,7 @@ class KohyaTrainer(BaseTrainer):
         Creates necessary directories.
         """
         # Create output directory
-        output_path = Path(self.config.output_dir)
-        if not output_path.is_absolute():
-            output_path = self.project_root / output_path
-        output_path.mkdir(parents=True, exist_ok=True)
+        self._resolved_output_dir().mkdir(parents=True, exist_ok=True)
 
         # Create config directory
         self.config_dir.mkdir(parents=True, exist_ok=True)
@@ -271,7 +272,7 @@ class KohyaTrainer(BaseTrainer):
             "--dataset_config",
             str(dataset_toml_user.resolve()),
             "--output_dir",
-            str(Path(self.config.output_dir).resolve()),
+            str(self._resolved_output_dir()),
             "--output_name",
             self.config.project_name,
         ]

--- a/services/trainers/kohya.py
+++ b/services/trainers/kohya.py
@@ -138,7 +138,7 @@ class KohyaTrainer(BaseTrainer):
             (is_valid, error_messages)
         """
         from services.core.validation import ValidationError as PathValidationError
-        from services.core.validation import validate_dataset_path, validate_model_path, validate_output_path
+        from services.core.validation import validate_dataset_path, validate_model_path
 
         errors = []
 
@@ -171,10 +171,15 @@ class KohyaTrainer(BaseTrainer):
             except PathValidationError as e:
                 errors.append(f"Invalid VAE path: {e}")
 
-        # Validate output directory
+        # Validate output directory is within safe bounds (project root or home).
+        # validate_output_path() is designed for filenames, not full directory paths,
+        # so we do the containment check inline here.
         try:
-            validate_output_path(self.config.output_dir)
-        except PathValidationError as e:
+            out_resolved = Path(self.config.output_dir).resolve()
+            allowed = [self.project_root, Path.home()]
+            if not any(out_resolved == a or out_resolved.is_relative_to(a) for a in allowed):
+                errors.append(f"Output directory outside allowed paths: {self.config.output_dir}")
+        except (ValueError, OSError) as e:
             errors.append(f"Invalid output path: {e}")
 
         # Flux/SD3/SD3.5/Chroma specific validation

--- a/services/trainers/kohya_toml.py
+++ b/services/trainers/kohya_toml.py
@@ -223,12 +223,34 @@ class KohyaTOMLGenerator:
     # (via `pip install -e .` on trainer/derrian_backend/custom_scheduler/),
     # so the import root is the package name, NOT the directory path.
     # Original paths from derrian's utils/validation.py.
+    CUSTOM_SCHEDULER_PATHS = {
+        "rex": "LoraEasyCustomOptimizer.RexAnnealingWarmRestarts.RexAnnealingWarmRestarts",
+        "cosine_annealing": "LoraEasyCustomOptimizer.CosineAnnealingWarmRestarts.CosineAnnealingWarmRestarts",
+    }
+
     CUSTOM_OPTIMIZER_PATHS = {
         "CAME": "LoraEasyCustomOptimizer.came.CAME",
         "Compass": "LoraEasyCustomOptimizer.compass.Compass",
         "LPFAdamW": "LoraEasyCustomOptimizer.lpfadamw.LPFAdamW",
         "RMSProp": "LoraEasyCustomOptimizer.rmsprop.RMSProp",
+        # Schedule-free optimizers (schedulefree package)
+        "AdamWScheduleFree": "schedulefree.AdamWScheduleFree",
+        "SGDScheduleFree": "schedulefree.SGDScheduleFree",
+        "RAdamScheduleFree": "schedulefree.RAdamScheduleFree",
     }
+
+    def _resolve_scheduler(self) -> dict:
+        """
+        Return the correct scheduler TOML key/value.
+
+        Standard schedulers use lr_scheduler = "cosine" etc.
+        Custom vendored schedulers use lr_scheduler_type = "dotted.Module.Class"
+        which Kohya resolves via importlib (same mechanism as custom optimizers).
+        """
+        path = self.CUSTOM_SCHEDULER_PATHS.get(self.config.lr_scheduler)
+        if path:
+            return {"lr_scheduler_type": path}
+        return {"lr_scheduler": self.config.lr_scheduler}
 
     def _resolve_optimizer_type(self, optimizer_type: str) -> str:
         """
@@ -311,7 +333,7 @@ class KohyaTOMLGenerator:
             "seed": self.config.seed,
             "unet_lr": self.config.unet_lr,
             "text_encoder_lr": self.config.text_encoder_lr,
-            "lr_scheduler": self.config.lr_scheduler,
+            **self._resolve_scheduler(),
             "lr_scheduler_num_cycles": self.config.lr_scheduler_number,
             # Kohya's --lr_warmup_steps accepts floats < 1 as ratios of total steps.
             # If user set a warmup ratio but no explicit steps, pass the ratio instead.


### PR DESCRIPTION
## Summary

- **VastAI log download crash** — `FileResponse` on an active log file snapshots `Content-Length` at creation time; file grows during streaming → Starlette 1.0 `RuntimeError` → uvicorn crash → Node.js ECONNRESET. Replaced with `StreamingResponse` + aiofiles generator (no `Content-Length` header, chunked transfer).
- **Job cancel TOCTOU race** — `stop_job` now sets `CANCELLED` before calling `terminate()` so `_monitor_job` can't race to mark the job `FAILED` first.
- **Output dir over-validation regression** (Qwen commit) — `validate_output_path` only permitted paths inside `project/output/`; replaced with inline containment check against `[project_root, home]`.
- **Community presets hidden** — Next.js preset list route omitted `is_builtin` from responses, so all server presets appeared under "Your Server Presets" instead of "Community Presets". `sanitizePresetId` also stripped spaces and dots from filenames, making load fail for most community presets (e.g. `lora_SDXL - LoRA AI_characters standard v1.0`). Old bmaltais-format presets now have their nested `config` keys hoisted to root on GET, with `LoRA_type → lora_type` rename.
- **6 new optimizers** — Compass, LPFAdamW, RMSProp (vendored LoraEasyCustomOptimizer), AdamWScheduleFree, SGDScheduleFree, RAdamScheduleFree (`schedulefree` package, already in requirements.txt).
- **2 new schedulers** — Rex and Cosine Annealing (Warm Restarts) via `lr_scheduler_type` dotted-path mechanism, mirroring the existing custom optimizer pattern.

## Test plan

- [ ] Download an active log file on VastAI — should stream without crash
- [ ] Cancel a running training job — status should show Cancelled not Failed
- [ ] Open training form with a custom output dir outside `project/output/` — validation should pass
- [ ] Open preset selector — community presets appear under "Community Presets" section
- [ ] Load a community preset with spaces in filename (e.g. any SDXL preset) — should populate form
- [ ] Select Compass / LPFAdamW / RMSProp from optimizer dropdown — visible and selectable
- [ ] Select AdamWScheduleFree / SGDScheduleFree / RAdamScheduleFree — visible and selectable
- [ ] Select Rex or Cosine Annealing from scheduler dropdown — visible and selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 6 new optimizer options and 2 new LR schedulers
  * Preset endpoints now surface creation date, builtin flag, and hoist nested config fields

* **Bug Fixes**
  * More reliable file downloads with improved streaming and attachment filenames
  * Stronger preset ID validation to prevent path traversal
  * More robust job cancellation/stop behavior

* **Chores**
  * Config filename sanitization updated to disallow spaces
<!-- end of auto-generated comment: release notes by coderabbit.ai -->