### PR TITLE
feat: auto-log browser errors to app.log via error boundaries

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from api.routes import civitai, config, dataset, files, models, settings, training, utilities
+from api.routes import civitai, config, dataset, debug, files, models, settings, training, utilities
 from services import websocket
 
 # Windows: ensure ProactorEventLoop so asyncio.create_subprocess_exec works
@@ -109,6 +109,7 @@ app.include_router(utilities.router, prefix="/api/utilities", tags=["Utilities"]
 app.include_router(models.router, prefix="/api/models", tags=["Models"])
 app.include_router(settings.router, prefix="/api/settings", tags=["Settings"])
 app.include_router(civitai.router, prefix="/api/civitai", tags=["Civitai"])
+app.include_router(debug.router, prefix="/api/debug", tags=["Debug"])
 
 # Include WebSocket routes (no prefix - they define their own paths)
 app.include_router(websocket.router, tags=["WebSocket"])

--- a/api/routes/debug.py
+++ b/api/routes/debug.py
@@ -17,6 +17,8 @@ router = APIRouter()
 
 
 class ClientError(BaseModel):
+    """Browser-side error payload sent by Next.js error boundaries."""
+
     message: str
     digest: Optional[str] = None
     stack: Optional[str] = None

--- a/api/routes/debug.py
+++ b/api/routes/debug.py
@@ -1,0 +1,40 @@
+"""
+API routes for client-side error reporting.
+Receives browser error reports from Next.js error boundaries and logs them
+to app.log so non-technical users don't need to open DevTools.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class ClientError(BaseModel):
+    message: str
+    digest: Optional[str] = None
+    stack: Optional[str] = None
+    url: Optional[str] = None
+    boundary: Optional[str] = None  # "route" or "global"
+
+
+@router.post("/client-error")
+async def log_client_error(error: ClientError):
+    """Receive and log browser-side errors from Next.js error boundaries."""
+    boundary_label = error.boundary or "unknown"
+    logger.error(
+        "🌐 Browser error [%s boundary] at %s: %s%s",
+        boundary_label,
+        error.url or "unknown URL",
+        error.message,
+        f" (digest: {error.digest})" if error.digest else "",
+    )
+    if error.stack:
+        logger.error("Stack trace:\n%s", error.stack)
+    return JSONResponse({"logged": True})

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -17,6 +17,17 @@ export default function Error({
 }) {
   useEffect(() => {
     console.error('Route error:', error);
+    fetch('/api/debug/client-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: error.message,
+        digest: error.digest,
+        stack: error.stack,
+        url: window.location.href,
+        boundary: 'route',
+      }),
+    }).catch(() => {});
   }, [error]);
 
   return (

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -7,6 +7,7 @@
 
 import { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
+import { debugAPI } from '@/lib/api';
 
 export default function Error({
   error,
@@ -17,16 +18,12 @@ export default function Error({
 }) {
   useEffect(() => {
     console.error('Route error:', error);
-    fetch('/api/debug/client-error', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        message: error.message,
-        digest: error.digest,
-        stack: error.stack,
-        url: window.location.href,
-        boundary: 'route',
-      }),
+    debugAPI.reportClientError({
+      message: error.message,
+      digest: error.digest,
+      stack: error.stack,
+      url: window.location.href,
+      boundary: 'route',
     }).catch(() => {});
   }, [error]);
 

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -9,6 +9,8 @@
  * layout has already failed when this renders.
  */
 
+import { useEffect } from 'react';
+
 export default function GlobalError({
   error,
   reset,
@@ -16,6 +18,20 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useEffect(() => {
+    fetch('/api/debug/client-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: error.message,
+        digest: error.digest,
+        stack: error.stack,
+        url: typeof window !== 'undefined' ? window.location.href : 'unknown',
+        boundary: 'global',
+      }),
+    }).catch(() => {});
+  }, [error]);
+
   return (
     <html lang="en">
       <body style={{
@@ -95,7 +111,7 @@ export default function GlobalError({
           </div>
 
           <p style={{ fontSize: 12, color: '#666', marginTop: 24 }}>
-            If this keeps happening, check the browser console (F12) and report the issue on GitHub.
+            If this keeps happening, please report the issue on GitHub with the error message above.
           </p>
         </div>
       </body>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1437,3 +1437,20 @@ export const presetsAPI = {
     return handleResponse(response);
   },
 };
+
+export const debugAPI = {
+  reportClientError: async (payload: {
+    message: string;
+    digest?: string;
+    stack?: string;
+    url?: string;
+    boundary?: string;
+  }): Promise<{ logged: boolean }> => {
+    const response = await fetch(`${API_BASE}/debug/client-error`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return handleResponse(response);
+  },
+};


### PR DESCRIPTION
## Summary

- Adds `POST /api/debug/client-error` FastAPI endpoint that receives browser error reports and writes them to `app.log`
- Updates `error.tsx` (route-level boundary) and `global-error.tsx` (root layout boundary) to automatically POST error details on mount
- Replaces the "check browser console (F12)" instruction in `global-error.tsx` with "report on GitHub with the error message above"

## Motivation

Closes / relates to #335 — dgracey01's blank `/training` page crash left zero trace in `app.log` or any other log file, making diagnosis impossible without the Next.js CMD window (which was long closed by the time the report was investigated). Non-technical users can't reliably use F12 or find the right CMD window, so errors need to surface automatically.

## What gets logged

When any error boundary fires, `app.log` will now contain:
```
🌐 Browser error [route|global boundary] at http://localhost:3000/training: <message> (digest: ...)
Stack trace:
  at ...
```

## Test plan

- [ ] Trigger a route-level error (e.g. throw in a page component) — check `app.log` shows `[route boundary]` entry
- [ ] Confirm the error message box still displays on screen as before
- [ ] Verify the footer note no longer mentions F12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic error reporting. The application now captures and reports client-side errors encountered during use, enabling better diagnostics and faster issue identification to improve overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->