### PR TITLE
Dev → Main: Windows fixes, test plumbing, AbortController cleanup, public agent docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,13 +205,12 @@ api_keys.txt
 hf_token.txt
 config/user_settings.json
 
-# Claude Code, Gemini & Qwen docs (private)
-CLAUDE.md
+# AI agent instruction files — public versions tracked, local variants private
+# AGENTS.md, CLAUDE.md, GEMINI.md, QWEN.md are intentionally tracked
 CLAUDE_*.md
-GEMINI.md
 GEMINI_*.md
-QWEN.md
 QWEN_*.md
+AGENTS_*.md
 TODO_*.md
 *_PLAN.md
 *_AUDIT.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,290 @@
+# AGENTS.md — Project Guide for AI Coding Agents
+
+This is the primary reference for any AI agent working in this repository.
+Agent-specific files (`CLAUDE.md`, `GEMINI.md`, `QWEN.md`) point here and add
+per-agent notes on top.
+
+---
+
+## CRITICAL RULES — Read These First
+
+### This is a WEB UI Project (NOT Jupyter Notebooks)
+
+This project uses **FastAPI + Next.js** for the interface, not Jupyter notebooks.
+
+- **NO** `.ipynb` files, notebook cells, or ipywidgets — ever
+- **YES** FastAPI backend (Python) + Next.js frontend (React/TypeScript)
+- Access via web browser at `http://localhost:3000`
+- If you see references to "notebooks" or "Jupyter" in existing code, they are outdated
+
+### Vendored Backend — No Submodules
+
+`trainer/derrian_backend/` is committed directly into the repository.
+
+- **DO** treat it as regular source code
+- **DO NOT** run `git submodule` commands — there are no submodules
+- **DO NOT** add git submodules to this repository
+- **DO NOT** modify vendored backend files unless explicitly asked
+
+### Do Not Change Server Bindings
+
+Do not change `0.0.0.0` to `localhost` or `127.0.0.1`:
+
+```python
+uvicorn.run(app, host="0.0.0.0", port=8000)  # correct — leave as-is
+```
+
+This application deploys to VastAI and RunPod cloud GPU instances. `0.0.0.0`
+is required for external access. Security is handled by the platform firewall
+and Cloudflare proxy. Do not change this even if a security scanner flags it.
+
+### Do Not Modify Git Remotes
+
+Never run commands that change remote configuration:
+
+```bash
+# Never run:
+git remote set-url origin ...
+git remote add ...
+git remote remove ...
+```
+
+### Do Not Create Audit Files
+
+Do not create markdown audit files (`API_AUDIT.md`, `ENDPOINT_AUDIT.md`, etc.)
+unless the user specifically asks for one. Report findings directly in the
+conversation instead.
+
+---
+
+## Repository Overview
+
+A **web-based** LoRA training environment for training LoRA models for Stable
+Diffusion image generation. Uses a FastAPI backend and Next.js frontend,
+designed to run cross-platform.
+
+**Architecture**: FastAPI (Python) + Next.js 15 (React/TypeScript) + Kohya SS
+
+**Deployment targets** (all equally supported):
+- **Windows local** — primary development environment; code must work here first
+- **VastAI** — Linux cloud GPU instances with auto-provisioning and supervisor
+- **RunPod** — Linux cloud GPU instances via `provision_runpod.sh`
+- **Training requirement** — NVIDIA GPU with CUDA 12.1+
+
+**Not supported**: macOS. Do not write Mac-specific code or instructions.
+
+---
+
+## Key Components
+
+### Backend — `api/`
+
+FastAPI route handlers:
+
+| File | Purpose |
+|------|---------|
+| `api/main.py` | FastAPI app entry point |
+| `api/routes/dataset.py` | Dataset upload and management |
+| `api/routes/training.py` | Training configuration and execution |
+| `api/routes/models.py` | Model downloads (HuggingFace / Civitai) |
+| `api/routes/utilities.py` | LoRA resizing and HuggingFace uploads |
+| `api/routes/config.py` | Configuration management |
+| `api/routes/files.py` | File operations and browsing |
+| `api/routes/settings.py` | Application settings |
+| `api/routes/civitai.py` | Civitai integration |
+| `api/routes/debug.py` | Debug and diagnostics |
+
+### Service Layer — `services/`
+
+Business logic. Route handlers call services; services call the training
+backend. Never call Kohya scripts directly from routes.
+
+| File / Dir | Purpose |
+|-----------|---------|
+| `training_service.py` | Training job orchestration |
+| `tagging_service.py` | WD14 image tagging |
+| `captioning_service.py` | BLIP / GIT captioning |
+| `dataset_service.py` | Dataset processing and validation |
+| `caption_service.py` | Caption file management |
+| `model_service.py` | Model download and management |
+| `lora_service.py` | LoRA utilities |
+| `websocket.py` | WebSocket handlers for real-time logs |
+| `jobs/` | Job management system |
+| `trainers/` | Training backend integration (Kohya SS) |
+| `models/` | Pydantic data models and schemas |
+| `core/` | Core utilities and path validation |
+
+### Frontend — `frontend/`
+
+Next.js 15 with React 19, TypeScript, and Tailwind CSS v4.
+
+| Dir | Purpose |
+|-----|---------|
+| `frontend/app/` | Next.js App Router pages |
+| `frontend/components/` | React components |
+| `frontend/lib/` | API client (`api.ts`) and utilities |
+| `frontend/hooks/` | Custom React hooks |
+
+All backend communication goes through `frontend/lib/api.ts`. Do not fetch the
+backend directly from components.
+
+### Training Backend — `trainer/derrian_backend/`
+
+Vendored Kohya SS distribution (committed directly, not a submodule):
+
+| Dir | Purpose |
+|-----|---------|
+| `sd_scripts/` | Kohya SS training scripts |
+| `lycoris/` | LyCORIS library |
+| `custom_scheduler/` | Custom optimizers (CAME, Compass, LPFAdamW, etc.) |
+
+### Startup Scripts
+
+| Script | Platform | Purpose |
+|--------|---------|---------|
+| `install.sh` / `install.bat` | Linux / Windows | Install dependencies |
+| `installer.py` | Both | Python dependency installer |
+| `start_services_local.sh` | Linux | Start locally |
+| `start_services_local.bat` | Windows | Start locally |
+| `start_services_vastai.sh` | VastAI | Supervisor-managed startup |
+| `provision_runpod.sh` | RunPod | Direct port binding startup |
+| `vastai_setup.sh` | VastAI | One-time provisioning |
+
+---
+
+## Development Commands
+
+### Installation
+
+```bash
+# Linux
+chmod +x ./install.sh && ./install.sh
+
+# Windows
+install.bat
+
+# Or directly
+python installer.py
+```
+
+### Start the Application
+
+**Linux:**
+```bash
+chmod +x ./start_services_local.sh
+./start_services_local.sh
+```
+
+**Windows:**
+```bat
+start_services_local.bat
+```
+
+Access:
+- Frontend: `http://localhost:3000`
+- Backend API: `http://localhost:8000`
+- API docs: `http://localhost:8000/docs`
+
+### Run Tests
+
+```bash
+pip install -r requirements_dev.txt
+pytest tests/test_api_plumbing.py -v
+```
+
+Tests are GPU-free and mock all ML dependencies. `tests/conftest.py` stubs
+missing production packages so tests run without the full venv.
+
+---
+
+## Platform and Path Rules
+
+- **Never hardcode paths** — use `sys.executable` and `os.path.join()`
+- **Primary dev OS is Windows 10** — do not write Unix-only solutions
+- **Deploy target is Linux** (VastAI / RunPod) — code must work on both
+- **Do not target macOS** — not a supported platform
+- Use `asyncio.create_subprocess_exec` for async subprocesses (not `subprocess.Popen` with shell)
+- `api/main.py` sets `asyncio.WindowsProactorEventLoopPolicy()` on Windows — do not remove
+
+---
+
+## Configuration System
+
+Training uses two TOML files generated by the backend API:
+
+- `trainer/runtime_store/dataset.toml` — dataset config (paths, resolution, batch size)
+- `trainer/runtime_store/config.toml` — training hyperparameters
+
+These are auto-generated from web UI form inputs. Check git history before
+modifying TOML generation logic — mistakes here affect real training runs.
+
+---
+
+## Frontend Rules
+
+### Use shadcn/ui Components — Mandatory
+
+Never use raw HTML form elements. This project uses shadcn/ui for all UI:
+
+| Avoid | Use instead |
+|-------|------------|
+| `<select>` | `<Select>` from `@/components/ui/select` |
+| `<input>` | `<Input>` from `@/components/ui/input` |
+| `<button>` | `<Button>` from `@/components/ui/button` |
+| `<textarea>` | `<Textarea>` from `@/components/ui/textarea` |
+
+### TypeScript and Patterns
+
+- TypeScript everywhere — no plain `.js` files in `frontend/`
+- Use the `@/` path alias, not relative paths
+- Mark components that use hooks or browser APIs with `'use client'`
+- Prefer server components when no client-side features are needed
+- Accessibility is mandatory — semantic HTML, keyboard navigation, ARIA attributes
+
+---
+
+## Code Quality Rules
+
+- **Complete functions** — never leave methods incomplete during refactoring
+- **Preserve all functionality** — UI changes are fine; business logic must stay intact
+- **Reference old code** when refactoring — compare with working versions before changing
+- **Ask before removing** — if unsure about a method's purpose, ask rather than delete
+- **Refactor incrementally** — test each step; do not do massive changes at once
+- **Compare method counts** before and after large refactors to catch missing functions
+- **Add docstrings inline** — when writing or modifying a function, update its docstring then and there
+
+---
+
+## What NOT to Do
+
+- Add Jupyter references to any file
+- Run `git submodule` commands
+- Modify git remotes
+- Change `0.0.0.0` server bindings
+- Hardcode absolute paths
+- Write macOS-only or Unix-only code
+- Edit `trainer/derrian_backend/` without explicit instruction
+- Add platform-specific npm packages directly (causes `EBADPLATFORM` on other OSes)
+- Create markdown audit files unless explicitly asked
+
+---
+
+## Supported Model Types
+
+- Stable Diffusion 1.5 (LoRA, LoCon, LoHa, LoKR)
+- SDXL (LoRA, LoCon, LoHa, LoKR)
+- Flux (experimental)
+- SD 3.5 (experimental)
+
+**Not yet supported**: Qwen Image LoRA — the vendored sd-scripts has the
+autoencoder but no training script. Do not add UI for it until upstream ships
+the training script.
+
+---
+
+## Current Status
+
+- Backend refactored to use Kohya's library system with strategy pattern
+- Frontend ~99% migrated to Next.js 15 + React 19 routes
+- Core training functionality works; in beta / bug-squashing phase
+- Flux and SD3 should work based on Kohya backend; needs real-world testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md — Claude Code Instructions
+
+See **[AGENTS.md](./AGENTS.md)** for the complete project guide — architecture,
+critical rules, key components, platform requirements, and code quality
+expectations. Everything there applies here too.
+
+This file adds Claude Code-specific guidance on top of that foundation.
+
+---
+
+## Claude Code Behaviour
+
+### Comments and Docstrings
+
+Default to writing **no comments**. Only add one when the WHY is non-obvious:
+a hidden constraint, a subtle invariant, or a workaround for a specific bug.
+Code that explains itself through good naming doesn't need a comment.
+
+Add or update docstrings **inline** when writing or modifying a function. Don't
+batch them into a separate pass — this prevents CodeRabbit from flagging missing
+docstrings as a separate concern on the PR. Don't use CodeRabbit's "generate
+docstrings" button; write them directly in the code.
+
+### Response Style
+
+Use clear, structured guidance. Prefer short, direct answers over long prose.
+When referencing code, include `file_path:line_number` so the user can navigate
+directly to it.
+
+### Security
+
+Run `snyk_code_scan` for any new first-party code in a Snyk-supported language.
+Fix issues before marking work complete, then re-scan to confirm.
+
+---
+
+## Frontend — shadcn/ui (Mandatory)
+
+Never use raw HTML form elements. This project uses shadcn/ui components:
+
+| Avoid | Use instead |
+|-------|------------|
+| `<select>` | `<Select>` from `@/components/ui/select` |
+| `<input>` | `<Input>` from `@/components/ui/input` |
+| `<button>` | `<Button>` from `@/components/ui/button` |
+| `<textarea>` | `<Textarea>` from `@/components/ui/textarea` |
+
+See `components/training/fields/FormFields.tsx` for examples of correct usage.
+
+---
+
+## Windows Development
+
+The primary development machine is **Windows 10**. When writing code:
+
+- Use `os.path.join()` or forward slashes — never hardcoded backslashes
+- `asyncio.WindowsProactorEventLoopPolicy` is set in `api/main.py` — do not remove
+- `start_services_local.bat` is the Windows startup script
+- Subprocess env vars `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` are required when
+  spawning Python subprocesses on Windows to avoid `UnicodeEncodeError` on cp1252
+- npm and Node commands must work from Windows CMD or PowerShell, not just bash
+- Path casing matters for webpack on Windows — NTFS is case-insensitive but webpack
+  is not; always use the correct mixed-case path
+
+---
+
+## Documentation Files
+
+- **AGENTS.md** — primary guide (architecture, rules, components)
+- **CLAUDE.md** — this file (Claude Code-specific additions)
+- **frontend/CLAUDE.md** — frontend-specific detail (Next.js, shadcn/ui, API client)
+- **README.md** — user-facing overview

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,47 @@
+# GEMINI.md — Gemini Code Assistant Instructions
+
+See **[AGENTS.md](./AGENTS.md)** for the complete project guide — architecture,
+critical rules, key components, platform requirements, and code quality
+expectations. Everything there applies here too.
+
+This file adds Gemini-specific notes on top of that foundation.
+
+---
+
+## Gemini-Specific Reminders
+
+### Do Not Modify Git Remotes
+
+Gemini tools have previously attempted to reconfigure remote URLs. The
+repository is already correctly configured. Never run any `git remote` commands.
+
+### Do Not Change 0.0.0.0 Bindings
+
+Gemini's security heuristics may flag `host="0.0.0.0"` in uvicorn or FastAPI
+startup calls. **Do not change these.** The binding is intentional for
+VastAI and RunPod cloud deployment. See AGENTS.md for the full explanation.
+
+### Outdated Path References
+
+The following paths appear in older Gemini conversation history but **do not
+exist** in the current codebase. Do not create or reference them:
+
+| Outdated | Correct |
+|---------|---------|
+| `core/managers.py` | `services/training_service.py` |
+| `core/dataset_manager.py` | `services/dataset_service.py` |
+| `core/kohya_training_manager.py` | `services/trainers/kohya.py` |
+| `core/utilities_manager.py` | `services/lora_service.py` |
+| `shared_managers.py` | does not exist |
+| `api/routers/` | `api/routes/` |
+| `frontend/src/` | `frontend/app/` |
+| `CLAUDE_DEVELOPMENT_RULES.md` | does not exist |
+| `CLAUDE_PROJECT_STATUS.md` | does not exist |
+
+Always read AGENTS.md → Key Components for accurate file locations.
+
+### Framework Versions
+
+- Next.js **15** (not 14) with React **19**
+- Tailwind CSS **v4**
+- Python 3.10+, Node.js 20+

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,0 +1,49 @@
+# QWEN.md — Qwen Code Assistant Instructions
+
+See **[AGENTS.md](./AGENTS.md)** for the complete project guide — architecture,
+critical rules, key components, platform requirements, and code quality
+expectations. Everything there applies here too.
+
+This file adds Qwen-specific notes on top of that foundation.
+
+---
+
+## Qwen-Specific Reminders
+
+### Do Not Change 0.0.0.0 Bindings
+
+`host="0.0.0.0"` in server startup calls is intentional for VastAI and RunPod
+cloud GPU deployment. Do not change to `localhost` or `127.0.0.1`.
+
+### Do Not Modify Git Remotes
+
+The repository remote is already correctly configured. Do not run any
+`git remote` commands.
+
+### Qwen Image LoRA — Not Supported Yet
+
+The vendored sd-scripts includes `library/qwen_image_autoencoder_kl.py` but
+there is no `networks/lora_qwen_image.py` and no training script. Do not add
+UI or backend support for Qwen Image LoRA until upstream ships the training
+script.
+
+### Outdated Path References
+
+The following paths appear in older documentation but **do not exist** in the
+current codebase. Do not create or reference them:
+
+| Outdated | Correct |
+|---------|---------|
+| `core/managers.py` | `services/training_service.py` |
+| `core/dataset_manager.py` | `services/dataset_service.py` |
+| `shared_managers.py` | does not exist |
+| `api/routers/` | `api/routes/` |
+| `frontend/src/` | `frontend/app/` |
+
+Always read AGENTS.md → Key Components for accurate file locations.
+
+### Framework Versions
+
+- Next.js **15** (not 14) with React **19**
+- Tailwind CSS **v4**
+- Python 3.10+, Node.js 20+

--- a/frontend/components/DatasetUploader.tsx
+++ b/frontend/components/DatasetUploader.tsx
@@ -40,6 +40,7 @@ export default function DatasetUploader() {
   // Direct Upload State
   const [datasetName, setDatasetName] = useState('my_dataset');
   const [files, setFiles] = useState<UploadedFile[]>([]);
+  const filesRef = useRef<UploadedFile[]>([]);
   const [uploading, setUploading] = useState(false);
   const uploadControllerRef = useRef<AbortController | null>(null);
 
@@ -85,6 +86,9 @@ export default function DatasetUploader() {
     const kohyaFolderName = folderName.trim() ? `${folderRepeats}_${folderName.trim()}` : '';
     setFolderExists(kohyaFolderName ? existingDatasets.includes(kohyaFolderName) : false);
   }, [folderName, folderRepeats, existingDatasets]);
+
+  // Keep filesRef in sync so the unmount cleanup always sees the latest files
+  useEffect(() => { filesRef.current = files; }, [files]);
 
   // ========== Direct Upload Handlers ==========
 
@@ -371,11 +375,13 @@ export default function DatasetUploader() {
     });
   }, []);
 
-  // Abort any in-flight upload and revoke blob URLs on unmount
+  // Abort any in-flight upload and revoke blob URLs on unmount.
+  // filesRef.current always holds the latest files list, so blob URLs created
+  // after mount are still revoked even though this effect has an empty dep array.
   useEffect(() => {
     return () => {
       uploadControllerRef.current?.abort();
-      revokePreviewUrls(files);
+      revokePreviewUrls(filesRef.current);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/frontend/components/DatasetUploader.tsx
+++ b/frontend/components/DatasetUploader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useDropzone } from 'react-dropzone';
 import {
   Upload,
@@ -41,6 +41,7 @@ export default function DatasetUploader() {
   const [datasetName, setDatasetName] = useState('my_dataset');
   const [files, setFiles] = useState<UploadedFile[]>([]);
   const [uploading, setUploading] = useState(false);
+  const uploadControllerRef = useRef<AbortController | null>(null);
 
   // URL/ZIP Download State
   const [projectName, setProjectName] = useState('');
@@ -160,6 +161,7 @@ export default function DatasetUploader() {
         console.error('Failed to reload datasets:', err);
       }
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
       console.error('Upload failed:', err);
       toast.error(`Upload failed: ${err}`);
     } finally {
@@ -229,6 +231,7 @@ export default function DatasetUploader() {
     formData.append('dataset_name', datasetName);
 
     const controller = new AbortController();
+    uploadControllerRef.current = controller;
     const timeoutId = setTimeout(() => controller.abort(), 600000);
 
     const response = await fetch(`${API_BASE}/dataset/upload-zip`, {
@@ -306,6 +309,7 @@ export default function DatasetUploader() {
 
       // Add timeout to prevent hanging forever (10 mins for slow networks)
       const controller = new AbortController();
+      uploadControllerRef.current = controller;
       const timeoutId = setTimeout(() => controller.abort(), 600000); // 10 minute timeout
 
       const response = await fetch(`${API_BASE}/dataset/upload-zip`, {
@@ -352,14 +356,9 @@ export default function DatasetUploader() {
         throw new Error(`No files extracted from ZIP (got ${result.extracted || 0} files)`);
       }
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
       console.error('❌ Upload error:', err);
-      if (err instanceof Error && err.name === 'AbortError') {
-        toast.error('ZIP upload timed out after 10 minutes', {
-          description: 'The network might be too slow or the backend crashed.',
-        });
-      } else {
-        toast.error(`ZIP upload failed: ${err}`);
-      }
+      toast.error(`ZIP upload failed: ${err}`);
     } finally {
       setUploading(false);
     }
@@ -372,9 +371,12 @@ export default function DatasetUploader() {
     });
   }, []);
 
-  // Revoke blob URLs on unmount
+  // Abort any in-flight upload and revoke blob URLs on unmount
   useEffect(() => {
-    return () => revokePreviewUrls(files);
+    return () => {
+      uploadControllerRef.current?.abort();
+      revokePreviewUrls(files);
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -128,13 +128,14 @@ export function pollJobLogs(
   let lastTimestamp = 0;
   let stopped = false;
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const controller = new AbortController();
 
   const poll = async () => {
     if (stopped) return;
 
     try {
       const url = `${API_BASE}/jobs/${jobId}/logs?since=${lastTimestamp}`;
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: controller.signal });
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
@@ -165,6 +166,7 @@ export function pollJobLogs(
         return;
       }
     } catch (err) {
+      if ((err as Error).name === 'AbortError') return;
       if (!stopped && onError) {
         onError(err instanceof Error ? err : new Error(String(err)));
       }
@@ -181,6 +183,7 @@ export function pollJobLogs(
 
   return {
     stop: () => {
+      controller.abort();
       stopped = true;
       if (timeoutId) clearTimeout(timeoutId);
     },
@@ -847,13 +850,14 @@ export const trainingAPI = {
     let nextSince = 0;
     let stopped = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const controller = new AbortController();
 
     const poll = async () => {
       if (stopped) return;
 
       try {
         const url = `${API_BASE}/training/logs/${jobId}?since=${nextSince}`;
-        const response = await fetch(url);
+        const response = await fetch(url, { signal: controller.signal });
 
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
@@ -886,6 +890,7 @@ export const trainingAPI = {
           return;
         }
       } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
         if (!stopped && onError) {
           onError(err instanceof Error ? err : new Error(String(err)));
         }
@@ -900,6 +905,7 @@ export const trainingAPI = {
 
     return {
       stop: () => {
+        controller.abort();
         stopped = true;
         if (timeoutId) clearTimeout(timeoutId);
       },

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,6 +2,20 @@
 const path = require('path');
 
 const nextConfig = {
+  // Pin React to a single copy — prevents duplicate-runtime crashes on Windows
+  // where NTFS path-casing can trick webpack into bundling react twice, breaking
+  // hooks and hydration.
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      react: path.resolve(__dirname, 'node_modules/react'),
+      'react-dom': path.resolve(__dirname, 'node_modules/react-dom'),
+      'react/jsx-runtime': path.resolve(__dirname, 'node_modules/react/jsx-runtime'),
+      'react/jsx-dev-runtime': path.resolve(__dirname, 'node_modules/react/jsx-dev-runtime'),
+    };
+    return config;
+  },
+
   // ✅ CVE-2026-27980: Cap image optimization disk cache (added in Next.js 15.5.14)
   images: {
     maximumDiskCacheSize: 500 * 1024 * 1024, // 500 MB

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ pytest-mock>=3.12           # mocker fixture (convenient wrapper around unittest
 httpx>=0.27                 # required by FastAPI TestClient for async route support
 
 # Runtime deps needed in the test env (tests import from services/ and api/)
-tomlkit                     # used by services/trainers/kohya_toml.py
+tomlkit>=0.13               # used by services/trainers/kohya_toml.py
 aiohttp>=3.13.3             # used by api/routes/civitai.py
 python-multipart>=0.0.22    # required by FastAPI routes that handle file uploads
 aiofiles>=23.2.1            # used by api/routes/files.py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,9 @@ pytest>=8.0
 pytest-asyncio>=0.23        # async test support (asyncio_mode = "auto" in pyproject.toml)
 pytest-mock>=3.12           # mocker fixture (convenient wrapper around unittest.mock)
 httpx>=0.27                 # required by FastAPI TestClient for async route support
+
+# Runtime deps needed in the test env (tests import from services/ and api/)
+tomlkit                     # used by services/trainers/kohya_toml.py
+aiohttp>=3.13.3             # used by api/routes/civitai.py
+python-multipart>=0.0.22    # required by FastAPI routes that handle file uploads
+aiofiles>=23.2.1            # used by api/routes/files.py

--- a/services/captioning_service.py
+++ b/services/captioning_service.py
@@ -8,6 +8,7 @@ Orchestrates BLIP/GIT captioning workflow:
 - Progress monitoring
 """
 
+import os
 import sys
 import asyncio
 import logging
@@ -75,11 +76,16 @@ class CaptioningService:
             command = self._build_blip_command(config)
 
             # Step 4: Start subprocess
+            env = os.environ.copy()
+            env["PYTHONUNBUFFERED"] = "1"
+            env["PYTHONIOENCODING"] = "utf-8"
+            env["PYTHONUTF8"] = "1"
             process = await asyncio.create_subprocess_exec(
                 *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=self.project_root,
+                env=env,
             )
 
             # Step 5: Register with job manager
@@ -136,11 +142,16 @@ class CaptioningService:
             command = self._build_git_command(config)
 
             # Step 4: Start subprocess
+            env = os.environ.copy()
+            env["PYTHONUNBUFFERED"] = "1"
+            env["PYTHONIOENCODING"] = "utf-8"
+            env["PYTHONUTF8"] = "1"
             process = await asyncio.create_subprocess_exec(
                 *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=self.project_root,
+                env=env,
             )
 
             # Step 5: Register with job manager

--- a/services/captioning_service.py
+++ b/services/captioning_service.py
@@ -8,7 +8,6 @@ Orchestrates BLIP/GIT captioning workflow:
 - Progress monitoring
 """
 
-import os
 import sys
 import asyncio
 import logging
@@ -25,6 +24,7 @@ from services.models.captioning import (
 from services.models.job import JobType, JobStatus
 from services.jobs import job_manager
 from services.core.exceptions import ValidationError
+from services.core.subprocess_env import python_subprocess_env
 from services.core.validation import validate_dataset_path
 
 logger = logging.getLogger(__name__)
@@ -76,16 +76,12 @@ class CaptioningService:
             command = self._build_blip_command(config)
 
             # Step 4: Start subprocess
-            env = os.environ.copy()
-            env["PYTHONUNBUFFERED"] = "1"
-            env["PYTHONIOENCODING"] = "utf-8"
-            env["PYTHONUTF8"] = "1"
             process = await asyncio.create_subprocess_exec(
                 *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=self.project_root,
-                env=env,
+                env=python_subprocess_env(),
             )
 
             # Step 5: Register with job manager
@@ -142,16 +138,12 @@ class CaptioningService:
             command = self._build_git_command(config)
 
             # Step 4: Start subprocess
-            env = os.environ.copy()
-            env["PYTHONUNBUFFERED"] = "1"
-            env["PYTHONIOENCODING"] = "utf-8"
-            env["PYTHONUTF8"] = "1"
             process = await asyncio.create_subprocess_exec(
                 *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=self.project_root,
-                env=env,
+                env=python_subprocess_env(),
             )
 
             # Step 5: Register with job manager

--- a/services/core/subprocess_env.py
+++ b/services/core/subprocess_env.py
@@ -1,0 +1,16 @@
+"""Shared subprocess environment helpers."""
+import os
+
+
+def python_subprocess_env() -> dict[str, str]:
+    """Return a copy of os.environ with UTF-8 I/O and unbuffered output forced.
+
+    Apply to every Python child process so Unicode-rich output (box-drawing
+    chars, emoji from accelerator.print()) doesn't crash on Windows cp1252, and
+    so stdout/stderr stream in real-time rather than buffering until exit.
+    """
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["PYTHONUTF8"] = "1"
+    return env

--- a/services/tagging_service.py
+++ b/services/tagging_service.py
@@ -8,7 +8,6 @@ Orchestrates WD14 tagger workflow:
 - Progress monitoring
 """
 
-import os
 import sys
 import asyncio
 import subprocess
@@ -24,6 +23,7 @@ from services.models.tagging import (
 from services.models.job import JobType, JobStatus
 from services.jobs import job_manager
 from services.core.exceptions import ValidationError, ProcessError
+from services.core.subprocess_env import python_subprocess_env
 from services.core.validation import validate_dataset_path
 
 logger = logging.getLogger(__name__)
@@ -70,16 +70,12 @@ class TaggingService:
             command = self._build_command(config, use_onnx)
 
             # Step 4: Start subprocess
-            env = os.environ.copy()
-            env["PYTHONUNBUFFERED"] = "1"
-            env["PYTHONIOENCODING"] = "utf-8"
-            env["PYTHONUTF8"] = "1"
             process = await asyncio.create_subprocess_exec(
                 *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=self.project_root,
-                env=env,
+                env=python_subprocess_env(),
             )
 
             # Step 5: Register with job manager

--- a/services/tagging_service.py
+++ b/services/tagging_service.py
@@ -8,6 +8,7 @@ Orchestrates WD14 tagger workflow:
 - Progress monitoring
 """
 
+import os
 import sys
 import asyncio
 import subprocess
@@ -69,11 +70,16 @@ class TaggingService:
             command = self._build_command(config, use_onnx)
 
             # Step 4: Start subprocess
+            env = os.environ.copy()
+            env["PYTHONUNBUFFERED"] = "1"
+            env["PYTHONIOENCODING"] = "utf-8"
+            env["PYTHONUTF8"] = "1"
             process = await asyncio.create_subprocess_exec(
                 *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=self.project_root,
+                env=env,
             )
 
             # Step 5: Register with job manager

--- a/services/trainers/base.py
+++ b/services/trainers/base.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Tuple
 
 # ✅ FIX C0415: Moved imports to top level
 from services.core.exceptions import ProcessError, ValidationError
+from services.core.subprocess_env import python_subprocess_env
 from services.models.training import TrainingConfig
 
 
@@ -93,7 +94,7 @@ class BaseTrainer(ABC):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=str(Path.cwd()),
-                env=os.environ.copy(),
+                env=python_subprocess_env(),
                 limit=1024 * 1024,  # 1MB line buffer — prevents LimitOverrunError on long Kohya output lines
             )
 

--- a/services/trainers/kohya.py
+++ b/services/trainers/kohya.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from services.core.exceptions import ConfigError, ValidationError
+from services.core.subprocess_env import python_subprocess_env
 from services.models.training import ModelType, TrainingConfig
 from services.trainers.base import BaseTrainer
 from services.trainers.kohya_toml import KohyaTOMLGenerator
@@ -109,7 +110,7 @@ class KohyaTrainer(BaseTrainer):
         try:
             # Build env with derrian_backend on PYTHONPATH so custom optimizers
             # (CAME, Compass, etc.) are importable from the sd_scripts cwd
-            env = os.environ.copy()
+            env = python_subprocess_env()
             derrian_dir = str(self.sd_scripts_dir.parent)  # trainer/derrian_backend
             custom_sched_dir = str(self.sd_scripts_dir.parent / "custom_scheduler")  # LoraEasyCustomOptimizer
             existing_pythonpath = env.get("PYTHONPATH", "")
@@ -117,13 +118,6 @@ class KohyaTrainer(BaseTrainer):
             # so LoraEasyCustomOptimizer.came.CAME etc. resolve even if editable install failed
             new_paths = f"{derrian_dir}{os.pathsep}{custom_sched_dir}"
             env["PYTHONPATH"] = f"{new_paths}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else new_paths
-            # Force unbuffered stdout so logs stream in real-time instead of arriving
-            # all at once when the process exits (Python buffers stdout when piped).
-            env["PYTHONUNBUFFERED"] = "1"
-            # Force UTF-8 I/O so Kohya's Unicode-rich output (box-drawing chars,
-            # arrows, emoji from accelerator.print()) doesn't crash on Windows cp1252.
-            env["PYTHONIOENCODING"] = "utf-8"
-            env["PYTHONUTF8"] = "1"
 
             process = await asyncio.create_subprocess_exec(
                 cmd[0],  # Program (python)

--- a/services/trainers/kohya.py
+++ b/services/trainers/kohya.py
@@ -120,6 +120,10 @@ class KohyaTrainer(BaseTrainer):
             # Force unbuffered stdout so logs stream in real-time instead of arriving
             # all at once when the process exits (Python buffers stdout when piped).
             env["PYTHONUNBUFFERED"] = "1"
+            # Force UTF-8 I/O so Kohya's Unicode-rich output (box-drawing chars,
+            # arrows, emoji from accelerator.print()) doesn't crash on Windows cp1252.
+            env["PYTHONIOENCODING"] = "utf-8"
+            env["PYTHONUTF8"] = "1"
 
             process = await asyncio.create_subprocess_exec(
                 cmd[0],  # Program (python)

--- a/start_services_local.bat
+++ b/start_services_local.bat
@@ -251,7 +251,7 @@ if exist "frontend\" (
         )
         if "!BACKEND_READY!"=="0" echo [WARN] Backend health not ready after ~60s, continuing anyway...
         echo [Frontend] Starting Next.js frontend on http://localhost:!FRONTEND_PORT!...
-        start "Ktiseos Frontend" /MIN cmd /c "cd frontend && set NODE_ENV=production && set PORT=!FRONTEND_PORT! && set BACKEND_PORT=!BACKEND_PORT! && npm start"
+        start "Ktiseos Frontend" /MIN cmd /c "cd /d %~dp0frontend&&set NODE_ENV=production&&set PORT=!FRONTEND_PORT!&&set BACKEND_PORT=!BACKEND_PORT!&&npm start"
     )
 )
 

--- a/start_services_local.bat
+++ b/start_services_local.bat
@@ -241,13 +241,15 @@ if exist "frontend\" (
             popd
         )
         echo [Frontend] Waiting for backend health on http://127.0.0.1:!BACKEND_PORT!/api/health ...
-        for /l %%i in (1,1,60) do (
-            powershell -NoProfile -Command "try { iwr -UseBasicParsing http://127.0.0.1:!BACKEND_PORT!/api/health -TimeoutSec 2 | Out-Null; exit 0 } catch { exit 1 }"
-            if not errorlevel 1 goto :BACKEND_READY
-            timeout /t 1 >nul
+        set "BACKEND_READY=0"
+        for /l %%i in (1,1,30) do (
+            if "!BACKEND_READY!"=="0" (
+                powershell -NoProfile -Command "try { iwr -UseBasicParsing http://127.0.0.1:!BACKEND_PORT!/api/health -TimeoutSec 2 | Out-Null; exit 0 } catch { exit 1 }"
+                if not errorlevel 1 set "BACKEND_READY=1"
+                if "!BACKEND_READY!"=="0" timeout /t 2 >nul
+            )
         )
-        echo [WARN] Backend health not ready after 60s, continuing anyway...
-        :BACKEND_READY
+        if "!BACKEND_READY!"=="0" echo [WARN] Backend health not ready after ~60s, continuing anyway...
         echo [Frontend] Starting Next.js frontend on http://localhost:!FRONTEND_PORT!...
         start "Ktiseos Frontend" /MIN cmd /c "cd frontend && set NODE_ENV=production && set PORT=!FRONTEND_PORT! && set BACKEND_PORT=!BACKEND_PORT! && npm start"
     )

--- a/start_services_local.bat
+++ b/start_services_local.bat
@@ -240,8 +240,16 @@ if exist "frontend\" (
             npm run build
             popd
         )
+        echo [Frontend] Waiting for backend health on http://127.0.0.1:!BACKEND_PORT!/api/health ...
+        for /l %%i in (1,1,60) do (
+            powershell -NoProfile -Command "try { iwr -UseBasicParsing http://127.0.0.1:!BACKEND_PORT!/api/health -TimeoutSec 2 | Out-Null; exit 0 } catch { exit 1 }"
+            if not errorlevel 1 goto :BACKEND_READY
+            timeout /t 1 >nul
+        )
+        echo [WARN] Backend health not ready after 60s, continuing anyway...
+        :BACKEND_READY
         echo [Frontend] Starting Next.js frontend on http://localhost:!FRONTEND_PORT!...
-        start "Ktiseos Frontend" /MIN cmd /c "cd frontend && set NODE_ENV=production&& set PORT=!FRONTEND_PORT!&& set BACKEND_PORT=!BACKEND_PORT!&& npm start"
+        start "Ktiseos Frontend" /MIN cmd /c "cd frontend && set NODE_ENV=production && set PORT=!FRONTEND_PORT! && set BACKEND_PORT=!BACKEND_PORT! && npm start"
     )
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,9 @@ _mp = _stub_if_absent("multipart")
 if not isinstance(getattr(_mp, "__version__", None), str):
     _mp.__version__ = "0.0.99"
 
-_mp_mp = _stub_if_absent("multipart.multipart")
-if not callable(getattr(_mp_mp, "parse_options_header", None)):
-    _mp_mp.parse_options_header = MagicMock()
+# Only stub multipart.multipart when the parent multipart was itself a stub
+# (i.e. not installed). If the real package is present we leave its internals alone.
+if getattr(_mp, "__version__", None) == "0.0.99":
+    _mp_mp = _stub_if_absent("multipart.multipart")
+    if not callable(getattr(_mp_mp, "parse_options_header", None)):
+        _mp_mp.parse_options_header = MagicMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+"""
+Stub heavy production deps before pytest collects any test module.
+
+Why this exists
+---------------
+services/__init__.py eagerly imports the full service layer on first import.
+Any test that touches `services.*` (even a subpackage like services.core)
+triggers that chain, which pulls in tomlkit, aiohttp, aiofiles, and
+python-multipart — all real packages that aren't needed for GPU-free unit tests.
+
+This file is loaded by pytest before collection begins (conftest.py semantics),
+so the stubs are in place before a single test module is imported.
+
+If a package is already installed (e.g. the user ran `pip install -r
+requirements_dev.txt`), _stub_if_absent() leaves sys.modules untouched so the
+real implementation is used instead of the mock.
+"""
+import sys
+from unittest.mock import MagicMock
+
+
+def _stub_if_absent(name: str) -> MagicMock:
+    """Insert a MagicMock into sys.modules only when the real package is absent."""
+    if name not in sys.modules:
+        sys.modules[name] = MagicMock()
+    return sys.modules[name]
+
+
+# tomlkit — kohya_toml.py uses it for TOML serialisation; no test triggers generation
+_stub_if_absent("tomlkit")
+
+# aiohttp — civitai.py uses it for HTTP proxying; no test calls Civitai endpoints
+_stub_if_absent("aiohttp")
+
+# aiofiles — files.py uses it for async file I/O; no test downloads files
+_stub_if_absent("aiofiles")
+
+# python-multipart — FastAPI evaluates __version__ > "0.0.12" at route-registration
+# time (string comparison).  Supply a real string so the assertion passes and
+# FastAPI can register file-upload routes without the real package installed.
+_pm = _stub_if_absent("python_multipart")
+if not isinstance(getattr(_pm, "__version__", None), str):
+    _pm.__version__ = "0.0.99"
+
+_mp = _stub_if_absent("multipart")
+if not isinstance(getattr(_mp, "__version__", None), str):
+    _mp.__version__ = "0.0.99"
+
+_mp_mp = _stub_if_absent("multipart.multipart")
+if not callable(getattr(_mp_mp, "parse_options_header", None)):
+    _mp_mp.parse_options_header = MagicMock()


### PR DESCRIPTION
## Summary

This merges the `dev` branch to `main`. The branch covers a wide range of work from stability fixes through to beta prep. Highlights from this session and recent commits below.

### Bug Fixes

- **#338 — UnicodeEncodeError on Windows (cp1252)**: Added `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` to the Kohya subprocess env so `accelerator.print()`'s Unicode-rich output no longer crashes at training start on Windows
- **#339 — Windows hardening**:
  - React webpack aliases in `next.config.js` to prevent duplicate React runtime from NTFS path-casing
  - `PYTHONUNBUFFERED` + UTF-8 env vars added to tagging and captioning subprocesses (live log streaming)
  - Backend health gate in `start_services_local.bat` — waits up to 60s for `/api/health` before launching Next.js to avoid SSR fetch races on cold boot
- **#348 — AbortController for in-flight request cancellation**:
  - `pollJobLogs()` and `trainingAPI.pollLogs` now hold an `AbortController`; `stop()` aborts the in-flight fetch immediately instead of waiting for it to resolve
  - `DatasetUploader` stores its upload `AbortController` in a ref so unmounting the component cancels the in-progress request; `AbortError` is silenced in catch blocks

### Tests

- **#351 — Test plumbing**: `tests/conftest.py` pre-populates `sys.modules` with `MagicMock` stubs for `tomlkit`, `aiohttp`, `aiofiles`, and `python-multipart` before pytest collection, so GPU-free tests run without the full venv
- `requirements_dev.txt` also lists those packages explicitly so CI can install the real implementations when desired
- All 10 tests in `tests/test_api_plumbing.py` now pass

### Docs

- **AGENTS.md** (new) — public primary guide for any AI coding agent; covers architecture, critical rules, component map, platform requirements, and code quality expectations
- **CLAUDE.md**, **GEMINI.md**, **QWEN.md** — rewritten as thin wrappers pointing to `AGENTS.md`; corrects outdated path references (`core/managers.py`, `api/routers/`, `frontend/src/`) in Gemini and Qwen files; adds Gemini-specific git-remote and 0.0.0.0 reminders
- All four files un-ignored in `.gitignore`; `*_*.md` variant patterns remain private

### Earlier Dev Work (since last main merge)

Community training presets, Anima model support, custom optimizer exposure (Compass, LPFAdamW, RMSProp, schedule-free), error boundaries with app.log integration, VastAI/RunPod provisioning improvements, Civitai browse fixes, path traversal hardening, security CVE patches, Windows installer improvements, TOML generation fixes, and more. See commit log for full detail.

## Test Plan

- [ ] `pytest tests/test_api_plumbing.py -v` — all 10 pass
- [ ] Windows: start backend → `start_services_local.bat` waits for health before launching frontend
- [ ] Training job started → logs stream in real-time (no blank log panel)
- [ ] Navigate away from training page mid-poll → no console AbortError toasts
- [ ] Upload dataset ZIP → navigate away mid-upload → no spurious "upload failed" toast

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive AI agent instruction files and updated ignore rules to track public instruction docs.

* **Bug Fixes**
  * Improved upload cancellation handling and job-polling cancellation.
  * Prevented duplicate React runtime issues affecting component stability.
  * Ensured consistent subprocess encoding/env for background services.
  * Frontend now waits for backend health before starting.

* **Tests**
  * Added test stubs/helpers for missing third‑party packages.

* **Chores**
  * Updated dev dependency list for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->