### PR TITLE
fix: Anima optimizer_args TOML type + shadcn 4.7.0 + docs cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,11 +199,13 @@ $RECYCLE.BIN/
 # ----------------------------------------------------------------------------
 *.env
 .env.*
-config.json
 secrets.json
 api_keys.txt
 hf_token.txt
 config/user_settings.json
+
+# Negation for the bundled model configs
+!trainer/derrian_backend/sd_scripts/configs/**/*.json
 
 # AI agent instruction files — public versions tracked, local variants private
 # AGENTS.md, CLAUDE.md, GEMINI.md, QWEN.md are intentionally tracked

--- a/example_configs/qwen3_06b/config.json
+++ b/example_configs/qwen3_06b/config.json
@@ -1,0 +1,30 @@
+{
+  "architectures": [
+    "Qwen3ForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 151643,
+  "eos_token_id": 151643,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 1024,
+  "initializer_range": 0.02,
+  "intermediate_size": 3072,
+  "max_position_embeddings": 32768,
+  "max_window_layers": 28,
+  "model_type": "qwen3",
+  "num_attention_heads": 16,
+  "num_hidden_layers": 28,
+  "num_key_value_heads": 8,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 1000000,
+  "sliding_window": null,
+  "tie_word_embeddings": true,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.51.0",
+  "use_cache": true,
+  "use_sliding_window": false,
+  "vocab_size": 151936
+}

--- a/example_configs/t5_old/config.json
+++ b/example_configs/t5_old/config.json
@@ -1,0 +1,51 @@
+{
+  "architectures": [
+    "T5WithLMHeadModel"
+  ],
+  "d_ff": 65536,
+  "d_kv": 128,
+  "d_model": 1024,
+  "decoder_start_token_id": 0,
+  "dropout_rate": 0.1,
+  "eos_token_id": 1,
+  "initializer_factor": 1.0,
+  "is_encoder_decoder": true,
+  "layer_norm_epsilon": 1e-06,
+  "model_type": "t5",
+  "n_positions": 512,
+  "num_heads": 128,
+  "num_layers": 24,
+  "output_past": true,
+  "pad_token_id": 0,
+  "relative_attention_num_buckets": 32,
+  "task_specific_params": {
+    "summarization": {
+      "early_stopping": true,
+      "length_penalty": 2.0,
+      "max_length": 200,
+      "min_length": 30,
+      "no_repeat_ngram_size": 3,
+      "num_beams": 4,
+      "prefix": "summarize: "
+    },
+    "translation_en_to_de": {
+      "early_stopping": true,
+      "max_length": 300,
+      "num_beams": 4,
+      "prefix": "translate English to German: "
+    },
+    "translation_en_to_fr": {
+      "early_stopping": true,
+      "max_length": 300,
+      "num_beams": 4,
+      "prefix": "translate English to French: "
+    },
+    "translation_en_to_ro": {
+      "early_stopping": true,
+      "max_length": 300,
+      "num_beams": 4,
+      "prefix": "translate English to Romanian: "
+    }
+  },
+  "vocab_size": 32128
+}

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,7 +20,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is the **frontend** subdirectory of the Ktiseos-Nyx-Trainer project. The parent repository is a **web-based LoRA training environment** with a FastAPI backend. This frontend provides a modern Next.js web interface for training LoRA models.
 
-**Architecture**: Next.js 15 (frontend) → FastAPI (backend) → Services (business logic) → Kohya SS (training)
+**Architecture**: Next.js 16 (frontend) → FastAPI (backend) → Services (business logic) → Kohya SS (training)
 
 **For backend/training documentation, see the parent directory's CLAUDE.md.**
 
@@ -51,7 +51,7 @@ npm run lint
 ## Architecture Overview
 
 ### Tech Stack
-- **Framework**: Next.js 15.5.14 (App Router, React 19 stable)
+- **Framework**: Next.js 16.2.4 (App Router, React 19 stable)
 - **Language**: TypeScript 5.4+
 - **Styling**: Tailwind CSS v4 with CSS custom properties for theming
 - **UI Components**: shadcn/ui ecosystem (Radix UI primitives)
@@ -59,9 +59,9 @@ npm run lint
 - **State Management**: React hooks + TanStack Query
 - **WebSockets**: Native WebSocket API for real-time logs
 
-### App Router Structure (Next.js 15)
+### App Router Structure (Next.js 16)
 
-The project uses Next.js 15's App Router with the following convention:
+The project uses Next.js 16's App Router with the following convention:
 - `app/` - All routes and pages
 - `app/layout.tsx` - Root layout with theme provider, navbar, footer
 - `app/page.tsx` - Homepage with animated hero
@@ -354,4 +354,4 @@ The frontend provides:
 3. **Use shadcn/ui components** - Check `SHADCN_COMPONENTS.md` before building custom
 4. **TypeScript everywhere** - No plain JavaScript files
 5. **API client centralization** - All backend calls through `lib/api.ts`
-6. **Security updates** - Next.js 15.5.14 (CVE-2026-27980, 29057, 33671, 33228 patched)
+6. **Security updates** - Next.js 16.2.4 (security bump from 15.x)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -95,7 +95,7 @@
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.5.0",
         "postcss": "^8.5.6",
-        "shadcn": "^3.6.1",
+        "shadcn": "^4.7.0",
         "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
@@ -115,28 +115,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@antfu/ni": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-25.0.0.tgz",
-      "integrity": "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansis": "^4.0.0",
-        "fzf": "^0.5.2",
-        "package-manager-detector": "^1.3.0",
-        "tinyexec": "^1.0.1"
-      },
-      "bin": {
-        "na": "bin/na.mjs",
-        "nci": "bin/nci.mjs",
-        "ni": "bin/ni.mjs",
-        "nlx": "bin/nlx.mjs",
-        "nr": "bin/nr.mjs",
-        "nun": "bin/nun.mjs",
-        "nup": "bin/nup.mjs"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6421,6 +6399,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/validate-npm-package-name": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
+      "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -7579,16 +7564,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -10055,13 +10030,6 @@
       "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fzf": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
-      "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
@@ -12680,13 +12648,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-manager-detector": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13850,19 +13811,19 @@
       "license": "ISC"
     },
     "node_modules/shadcn": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-3.6.1.tgz",
-      "integrity": "sha512-ClAtlvtyWVVzM87NCQyivSNSEPQEPLOAVCvey8rr6CukNyK2JeLNzJTdo9+4kpS/BSpx2MvQT+g+/V6ymZWmoQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.7.0.tgz",
+      "integrity": "sha512-70fwnesNrY1GgeD7Kdzn+3SsYeyfibm8immsA5L68+OusoPTvYF01oWExl8/latKpMpvVXcbgdbbE6VFBJQ38w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@antfu/ni": "^25.0.0",
         "@babel/core": "^7.28.0",
         "@babel/parser": "^7.28.0",
         "@babel/plugin-transform-typescript": "^7.28.0",
         "@babel/preset-typescript": "^7.27.1",
         "@dotenvx/dotenvx": "^1.48.4",
-        "@modelcontextprotocol/sdk": "^1.17.2",
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@types/validate-npm-package-name": "^4.0.2",
         "browserslist": "^4.26.2",
         "commander": "^14.0.0",
         "cosmiconfig": "^9.0.0",
@@ -13884,8 +13845,10 @@
         "prompts": "^2.4.2",
         "recast": "^0.23.11",
         "stringify-object": "^5.0.0",
+        "tailwind-merge": "^3.0.1",
         "ts-morph": "^26.0.0",
         "tsconfig-paths": "^4.2.0",
+        "validate-npm-package-name": "^7.0.1",
         "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.6"
       },
@@ -14555,16 +14518,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -15092,6 +15045,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.5.0",
     "postcss": "^8.5.6",
-    "shadcn": "^3.6.1",
+    "shadcn": "^4.7.0",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ voluptuous>=0.15.2
 sentencepiece>=0.2.1
 wheel>=0.38.1  # SNYK-PYTHON-WHEEL-3180413 (CVE-2022-40898): path traversal in wheel install
 matplotlib==3.10.1
-ramtorch
+ramtorch==0.2.3
 
 # Image/Data Handling
 Pillow>=10.3.0
@@ -69,7 +69,7 @@ werkzeug>=3.0.3  # SNYK-PYTHON-WERKZEUG-6035177/6808933: transitive via wandb/te
 filelock>=3.16.0  # SNYK-PYTHON-FILELOCK-14458335/14912448: transitive via huggingface-hub
 urllib3>=2.4.0  # SNYK-PYTHON-URLLIB3-14192442/14192443/14896210: transitive via requests
 Markdown>=3.7.0  # SNYK-PYTHON-MARKDOWN-15428352: transitive via tensorboard/wandb
-kornia
+kornia>=0.8.2
 
 
 # Monitoring & Logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ voluptuous>=0.15.2
 sentencepiece>=0.2.1
 wheel>=0.38.1  # SNYK-PYTHON-WHEEL-3180413 (CVE-2022-40898): path traversal in wheel install
 matplotlib==3.10.1
-
+ramtorch
 
 # Image/Data Handling
 Pillow>=10.3.0
@@ -69,6 +69,8 @@ werkzeug>=3.0.3  # SNYK-PYTHON-WERKZEUG-6035177/6808933: transitive via wandb/te
 filelock>=3.16.0  # SNYK-PYTHON-FILELOCK-14458335/14912448: transitive via huggingface-hub
 urllib3>=2.4.0  # SNYK-PYTHON-URLLIB3-14192442/14192443/14896210: transitive via requests
 Markdown>=3.7.0  # SNYK-PYTHON-MARKDOWN-15428352: transitive via tensorboard/wandb
+kornia
+
 
 # Monitoring & Logging
 wandb==0.17.1

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -51,7 +51,7 @@ voluptuous>=0.15.2
 sentencepiece>=0.2.1
 wheel
 matplotlib==3.10.1
-
+ramtorch
 
 # Image/Data Handling
 Pillow>=10.3.0
@@ -62,6 +62,7 @@ pyarrow>=16.1.0
 Jinja2>=3.1.6  # CVE fixes: alerts #60, #61, #63 (sandbox breakouts)
 imagesize>=1.4.1
 setuptools>=78.1.1
+kornia
 
 # Monitoring & Logging
 wandb==0.17.1

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -51,7 +51,7 @@ voluptuous>=0.15.2
 sentencepiece>=0.2.1
 wheel
 matplotlib==3.10.1
-ramtorch
+ramtorch==0.2.3
 
 # Image/Data Handling
 Pillow>=10.3.0
@@ -62,7 +62,7 @@ pyarrow>=16.1.0
 Jinja2>=3.1.6  # CVE fixes: alerts #60, #61, #63 (sandbox breakouts)
 imagesize>=1.4.1
 setuptools>=78.1.1
-kornia
+kornia>=0.8.2
 
 # Monitoring & Logging
 wandb==0.17.1

--- a/services/trainers/kohya_toml.py
+++ b/services/trainers/kohya_toml.py
@@ -440,7 +440,9 @@ class KohyaTOMLGenerator:
         if self.config.log_prefix:
             args["log_prefix"] = self.config.log_prefix
         if self.config.optimizer_args:
-            args["optimizer_args"] = self.config.optimizer_args
+            # Kohya expects optimizer_args as a list of "key=value" strings in TOML,
+            # not a single space-separated string.
+            args["optimizer_args"] = self.config.optimizer_args.split()
 
         # Save/sample intervals - only include when > 0 to avoid ZeroDivisionError
         # (Kohya does `global_step % save_every_n_steps` which crashes on 0)

--- a/services/trainers/kohya_toml.py
+++ b/services/trainers/kohya_toml.py
@@ -6,6 +6,7 @@ Generates FLAT toml files compatible with sd-scripts train_network.py variants.
 
 import logging
 import os
+import shlex
 from pathlib import Path
 from typing import Any, Dict
 
@@ -441,8 +442,8 @@ class KohyaTOMLGenerator:
             args["log_prefix"] = self.config.log_prefix
         if self.config.optimizer_args:
             # Kohya expects optimizer_args as a list of "key=value" strings in TOML,
-            # not a single space-separated string.
-            args["optimizer_args"] = self.config.optimizer_args.split()
+            # not a single space-separated string. shlex.split preserves quoted values.
+            args["optimizer_args"] = shlex.split(self.config.optimizer_args)
 
         # Save/sample intervals - only include when > 0 to avoid ZeroDivisionError
         # (Kohya does `global_step % save_every_n_steps` which crashes on 0)

--- a/trainer/derrian_backend/sd_scripts/configs/qwen3_06b/config.json
+++ b/trainer/derrian_backend/sd_scripts/configs/qwen3_06b/config.json
@@ -1,0 +1,30 @@
+{
+  "architectures": [
+    "Qwen3ForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 151643,
+  "eos_token_id": 151643,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 1024,
+  "initializer_range": 0.02,
+  "intermediate_size": 3072,
+  "max_position_embeddings": 32768,
+  "max_window_layers": 28,
+  "model_type": "qwen3",
+  "num_attention_heads": 16,
+  "num_hidden_layers": 28,
+  "num_key_value_heads": 8,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 1000000,
+  "sliding_window": null,
+  "tie_word_embeddings": true,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.51.0",
+  "use_cache": true,
+  "use_sliding_window": false,
+  "vocab_size": 151936
+}

--- a/trainer/derrian_backend/sd_scripts/configs/t5_old/config.json
+++ b/trainer/derrian_backend/sd_scripts/configs/t5_old/config.json
@@ -1,0 +1,51 @@
+{
+  "architectures": [
+    "T5WithLMHeadModel"
+  ],
+  "d_ff": 65536,
+  "d_kv": 128,
+  "d_model": 1024,
+  "decoder_start_token_id": 0,
+  "dropout_rate": 0.1,
+  "eos_token_id": 1,
+  "initializer_factor": 1.0,
+  "is_encoder_decoder": true,
+  "layer_norm_epsilon": 1e-06,
+  "model_type": "t5",
+  "n_positions": 512,
+  "num_heads": 128,
+  "num_layers": 24,
+  "output_past": true,
+  "pad_token_id": 0,
+  "relative_attention_num_buckets": 32,
+  "task_specific_params": {
+    "summarization": {
+      "early_stopping": true,
+      "length_penalty": 2.0,
+      "max_length": 200,
+      "min_length": 30,
+      "no_repeat_ngram_size": 3,
+      "num_beams": 4,
+      "prefix": "summarize: "
+    },
+    "translation_en_to_de": {
+      "early_stopping": true,
+      "max_length": 300,
+      "num_beams": 4,
+      "prefix": "translate English to German: "
+    },
+    "translation_en_to_fr": {
+      "early_stopping": true,
+      "max_length": 300,
+      "num_beams": 4,
+      "prefix": "translate English to French: "
+    },
+    "translation_en_to_ro": {
+      "early_stopping": true,
+      "max_length": 300,
+      "num_beams": 4,
+      "prefix": "translate English to Romanian: "
+    }
+  },
+  "vocab_size": 32128
+}


### PR DESCRIPTION
## Summary

- **Bug fix**: `optimizer_args` was being written as a string in the generated TOML but Kohya expects a list of `key=value` strings. This silently passed for XL-style models but breaks Anima's stricter training script parser.
- **Maintenance**: Bumps `shadcn` CLI from `3.6.1` → `4.7.0` to pick up upstream dependency vulnerability fixes instead of having to patch them manually. Regenerates frontend lockfile.
- **Docs**: Updates all Next.js 15 references in `frontend/CLAUDE.md` to 16.2.4.

## Test plan

- [ ] Start an Anima training run with optimizer args set — verify TOML is generated with `optimizer_args = ["key=value", ...]` list format
- [ ] Confirm `npm install` in `frontend/` resolves shadcn 4.7.0 cleanly
- [ ] Check GitHub security tab after merge — 2 high vulns on main should be addressed by the shadcn bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added model configurations for Qwen3 (6B) and T5 models.

* **Documentation**
  - Updated frontend documentation for Next.js 16.2.4 compatibility.

* **Bug Fixes**
  - Fixed optimizer arguments serialization in training configuration generation.

* **Chores**
  - Updated frontend dependencies (shadcn ^4.7.0).
  - Added Python dependencies: ramtorch and kornia.
  - Enhanced .gitignore with targeted sensitive file exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->