### PR TITLE
fix: form persistence, HF token save, clip_skip default, training monitor CR fixes

### DIFF
--- a/frontend/app/api/config/form/route.ts
+++ b/frontend/app/api/config/form/route.ts
@@ -1,0 +1,52 @@
+/**
+ * GET  /api/config/form  — Load last training form state (JSON)
+ * POST /api/config/form  — Save current training form state (JSON)
+ *
+ * Provides server-side persistence for the training form so state survives
+ * browser sessions where localStorage is cleared (adblockers, tracker
+ * blockers, privacy browsers, fresh VastAI connections, etc.).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import path from 'path';
+
+function formConfigPath(): string {
+  const projectRoot = path.resolve(process.cwd(), '..');
+  return path.join(projectRoot, 'config', 'last_training_form.json');
+}
+
+/**
+ * GET /api/config/form
+ * Returns the last saved training form state, or 404 if none exists yet.
+ */
+export async function GET() {
+  try {
+    const filePath = formConfigPath();
+    const content = await fs.readFile(filePath, 'utf-8');
+    return NextResponse.json({ success: true, config: JSON.parse(content) });
+  } catch {
+    return NextResponse.json({ success: false }, { status: 404 });
+  }
+}
+
+/**
+ * POST /api/config/form
+ * Saves the current training form state for cross-session recovery.
+ *
+ * @param request - Body should be the full TrainingConfig object.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const config = await request.json();
+    const filePath = formConfigPath();
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, JSON.stringify(config, null, 2), 'utf-8');
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/huggingface-upload/page.tsx
+++ b/frontend/app/huggingface-upload/page.tsx
@@ -23,6 +23,8 @@ export default function HuggingFaceUploadPage() {
   const [availableFiles, setAvailableFiles] = useState<LoRAFile[]>([]);
   const [tokenValid, setTokenValid] = useState<boolean | null>(null);
   const [useStoredToken, setUseStoredToken] = useState(false);
+  const [savingToken, setSavingToken] = useState(false);
+  const [tokenSaved, setTokenSaved] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [uploadResult, setUploadResult] = useState<any>(null);
   const [error, setError] = useState<string | null>(null);
@@ -93,6 +95,25 @@ export default function HuggingFaceUploadPage() {
       }
     } catch (err) {
       setTokenValid(false);
+    }
+  };
+
+  const handleSaveToken = async () => {
+    if (!hfToken.trim()) return;
+    setSavingToken(true);
+    try {
+      const res = await fetch('/api/settings/user', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ huggingface_token: hfToken }),
+      });
+      if (res.ok) {
+        setUseStoredToken(true);
+        setTokenSaved(true);
+        setTimeout(() => setTokenSaved(false), 3000);
+      }
+    } finally {
+      setSavingToken(false);
     }
   };
 
@@ -227,11 +248,29 @@ export default function HuggingFaceUploadPage() {
                   className="flex-1"
                   placeholder={useStoredToken ? 'Using saved token — type to override' : 'hf_...'}
                 />
-                <Button type="button" onClick={handleValidateToken}>
+                <Button type="button" onClick={handleValidateToken} disabled={!hfToken.trim()}>
                   Validate
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={handleSaveToken}
+                  disabled={!hfToken.trim() || savingToken}
+                >
+                  {savingToken ? <Loader2 className="w-4 h-4 animate-spin" /> : tokenSaved ? <CheckCircle className="w-4 h-4" /> : 'Save'}
                 </Button>
               </div>
 
+              {tokenSaved && (
+                <p className="mt-2 text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+                  <CheckCircle className="w-3 h-3" /> Token saved — will be remembered next time
+                </p>
+              )}
+              {useStoredToken && !hfToken && (
+                <p className="mt-2 text-xs text-cyan-600 dark:text-cyan-400">
+                  Using saved token from settings
+                </p>
+              )}
               {tokenValid !== null && (
                 <div className={`mt-2 flex items-center gap-2 text-sm ${tokenValid ? 'text-green-600' : 'text-red-600'}`}>
                   {tokenValid ? <CheckCircle className="w-4 h-4" /> : <XCircle className="w-4 h-4" />}

--- a/frontend/components/training/TrainingConfig.tsx
+++ b/frontend/components/training/TrainingConfig.tsx
@@ -155,6 +155,13 @@ export default function TrainingConfigNew() {
       const response = await trainingAPI.start(validatedConfig);
       if (response.success) {
         setTrainingJobId(response.job_id || null);
+        // Persist form state server-side so it survives browser sessions
+        // where localStorage is cleared (adblockers, privacy browsers, etc.)
+        fetch('/api/config/form', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(validatedConfig),
+        }).catch(() => { /* non-critical — don't block training start */ });
         // Store job ID for TrainingMonitor to pick up
         if (response.job_id && typeof window !== 'undefined') {
           localStorage.setItem('current_training_job_id', response.job_id);

--- a/frontend/components/training/TrainingConfig.tsx
+++ b/frontend/components/training/TrainingConfig.tsx
@@ -157,11 +157,7 @@ export default function TrainingConfigNew() {
         setTrainingJobId(response.job_id || null);
         // Persist form state server-side so it survives browser sessions
         // where localStorage is cleared (adblockers, privacy browsers, etc.)
-        fetch('/api/config/form', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(validatedConfig),
-        }).catch(() => { /* non-critical — don't block training start */ });
+        configAPI.saveForm(validatedConfig).catch(() => { /* non-critical */ });
         // Store job ID for TrainingMonitor to pick up
         if (response.job_id && typeof window !== 'undefined') {
           localStorage.setItem('current_training_job_id', response.job_id);

--- a/frontend/hooks/useTrainingForm.ts
+++ b/frontend/hooks/useTrainingForm.ts
@@ -10,6 +10,7 @@ import { useForm, UseFormReturn } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { TrainingConfigSchema } from '@/lib/validation';
+import { configAPI } from '@/lib/api';
 import type { ModelType, TrainingConfig } from '@/lib/api';
 
 const STORAGE_KEY = 'training-config';
@@ -303,12 +304,11 @@ export function useTrainingForm(options: {
       setIsHydrated(true);
     } else {
       // localStorage empty — try server-side last saved form state
-      fetch('/api/config/form')
-        .then((r) => r.ok ? r.json() : null)
-        .then((data) => {
-          if (data?.success && data.config) {
-            formRef.current.reset(data.config, { keepDefaultValues: false });
-            console.log('Hydrated form from server:', data.config.project_name);
+      configAPI.loadForm()
+        .then((config) => {
+          if (config) {
+            formRef.current.reset(config, { keepDefaultValues: false });
+            console.log('Hydrated form from server:', config.project_name);
           }
         })
         .catch(() => { /* server may not have a saved form yet — that's fine */ })

--- a/frontend/hooks/useTrainingForm.ts
+++ b/frontend/hooks/useTrainingForm.ts
@@ -91,7 +91,7 @@ const defaultConfig: TrainingConfig = {
   gradient_accumulation_steps: 1,
   max_grad_norm: 1.0,
   keep_tokens: 0,
-  clip_skip: 2,
+  clip_skip: 1,
   max_token_length: 225,
   caption_dropout_rate: 0.0,
   caption_tag_dropout_rate: 0.0,

--- a/frontend/hooks/useTrainingForm.ts
+++ b/frontend/hooks/useTrainingForm.ts
@@ -290,7 +290,8 @@ export function useTrainingForm(options: {
   const formRef = useRef(form);
   formRef.current = form;
 
-  // 1. Hydrate from localStorage ONCE on client mount
+  // 1. Hydrate from localStorage, falling back to server if localStorage is
+  //    empty (adblockers, privacy browsers, and fresh cloud sessions wipe it).
   useEffect(() => {
     if (isHydratedRef.current) return;
 
@@ -298,10 +299,24 @@ export function useTrainingForm(options: {
     if (stored) {
       formRef.current.reset(stored, { keepDefaultValues: false });
       console.log('Hydrated form from localStorage:', stored.project_name);
+      isHydratedRef.current = true;
+      setIsHydrated(true);
+    } else {
+      // localStorage empty — try server-side last saved form state
+      fetch('/api/config/form')
+        .then((r) => r.ok ? r.json() : null)
+        .then((data) => {
+          if (data?.success && data.config) {
+            formRef.current.reset(data.config, { keepDefaultValues: false });
+            console.log('Hydrated form from server:', data.config.project_name);
+          }
+        })
+        .catch(() => { /* server may not have a saved form yet — that's fine */ })
+        .finally(() => {
+          isHydratedRef.current = true;
+          setIsHydrated(true);
+        });
     }
-
-    isHydratedRef.current = true;
-    setIsHydrated(true);
   }, []);
 
   // 2. Auto-save: watch form changes → write to localStorage (debounced)

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1011,6 +1011,35 @@ export const configAPI = {
     const response = await fetch(`${API_BASE}/config/defaults`);
     return handleResponse(response);
   },
+
+  /**
+   * Save the training form state as JSON for cross-session recovery.
+   * Persists to config/last_training_form.json on the server so the form
+   * survives browser sessions where localStorage is cleared.
+   *
+   * @param config - Full training form values
+   */
+  saveForm: async (config: TrainingConfig): Promise<void> => {
+    const response = await fetch(`${API_BASE}/config/form`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config),
+    });
+    if (!response.ok) throw new Error(`saveForm: HTTP ${response.status}`);
+  },
+
+  /**
+   * Load the last saved training form state from the server.
+   * Returns null if no saved state exists yet.
+   *
+   * @returns The saved TrainingConfig, or null if not found
+   */
+  loadForm: async (): Promise<TrainingConfig | null> => {
+    const response = await fetch(`${API_BASE}/config/form`);
+    if (!response.ok) return null;
+    const data = await response.json();
+    return data?.success && data.config ? data.config : null;
+  },
 };
 
 // ========== Utilities Operations ==========


### PR DESCRIPTION
## Summary

Follow-up fixes from today's session — CodeRabbit feedback on PR #367, plus a handful of small UX bugs caught during live Anima training.

**CodeRabbit feedback (PR #367)**
- `JobStatus` model was missing `step_num/total_steps/loss/lr/eta_seconds` — `get_job_status()` stored them on `Job` but never passed them through to the status endpoint
- `log_parser.py`: ETA-only tqdm lines were discarded because `found_anything` wasn't set after the ETA block
- `api.ts`: `step_progress` emission guard was too narrow — `lr`/`total_steps`/`current_epoch`/`total_epochs`-only updates were dropped
- `TrainingMonitor.tsx`: 15s drain safety timeout was not cancellable; added `drainTimeoutRef` so a new job starting quickly doesn't desync the Live indicator
- README: Anima confirmed working, status updated to "Approaching Beta", hardware reference generalised

**UX fixes caught during training**
- `clip_skip` defaulted to `2` (SD1.5 era) — modern models expect `1`
- HF upload page had no way to save the token to settings from the upload form itself — users had to go to Settings separately and re-enter it every session; added Save button with 3s confirmation and a "Using saved token" indicator on return visits
- Footer logo linked to `/`, accidentally sending users home when misclicked mid-training; converted to a non-navigating `div`
- Training form reset between browser sessions because localStorage is unreliable with adblockers/privacy browsers; added `GET/POST /api/config/form` endpoints that persist the full form JSON to `config/last_training_form.json` on disk; hydration now falls back to server copy silently when localStorage is empty

## Test plan

- [ ] Start training — verify step/loss/LR/ETA stats populate in the monitor
- [ ] Open HF upload page, enter token, hit Save — navigate away and back, confirm "Using saved token" shows
- [ ] Click footer logo area mid-training — confirm no accidental navigation
- [ ] Submit training form, close browser, reopen — confirm form restores from server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training form configuration is now automatically saved and restored across browser sessions.
  * HuggingFace token can be saved with a dedicated button and success confirmation.
  * Previously saved settings are automatically loaded when restarting your session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->