### PR TITLE
fix: correct Kohya TOML arg mapping and sort preset list by model type

### DIFF
--- a/frontend/components/training/PresetManager.tsx
+++ b/frontend/components/training/PresetManager.tsx
@@ -20,13 +20,41 @@ import {
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { presetsAPI, type TrainingConfig, type PresetMetadata } from '@/lib/api';
+
+const MODEL_TYPE_ORDER = ['SD15', 'SDXL', 'FLUX', 'SD3', 'SD3.5', 'LUMINA', 'Chroma', 'Anima', 'HunyuanImage'];
+
+function groupByModelType<T>(presets: T[], getType: (p: T) => string | undefined, getName: (p: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const preset of presets) {
+    const type = getType(preset) || 'Other';
+    if (!groups.has(type)) groups.set(type, []);
+    groups.get(type)!.push(preset);
+  }
+  for (const items of groups.values()) {
+    items.sort((a, b) => getName(a).localeCompare(getName(b)));
+  }
+  return groups;
+}
+
+function sortedModelTypeKeys(groups: Map<string, unknown[]>): string[] {
+  return [...groups.keys()].sort((a, b) => {
+    const ai = MODEL_TYPE_ORDER.indexOf(a);
+    const bi = MODEL_TYPE_ORDER.indexOf(b);
+    if (ai !== -1 && bi !== -1) return ai - bi;
+    if (ai !== -1) return -1;
+    if (bi !== -1) return 1;
+    return a.localeCompare(b);
+  });
+}
 
 const LEGACY_OBSOLETE_FIELDS = new Set([
   'train_text_encoder', 'xformers', 'mem_eff_attn', 'use_8bit_adam',
@@ -385,60 +413,65 @@ export default function PresetManager({
                 <SelectValue placeholder="Choose a preset..." />
               </SelectTrigger>
               <SelectContent>
-                {serverPresets.filter(p => p.is_builtin).length > 0 && (
-                  <>
-                    <div className="px-2 py-1.5 text-xs font-semibold text-purple-400">
-                      Built-in Presets
-                    </div>
-                    {serverPresets.filter(p => p.is_builtin).map((preset) => (
-                      <SelectItem key={preset.id} value={preset.id}>
-                        <div className="flex items-center gap-2">
-                          <Badge variant="outline" className="text-xs">
-                            {preset.model_type}
-                          </Badge>
-                          {preset.name}
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </>
-                )}
+                {(() => {
+                  const builtins = serverPresets.filter(p => p.is_builtin);
+                  const userServer = serverPresets.filter(p => !p.is_builtin);
+                  const builtinGroups = groupByModelType(builtins, p => p.model_type, p => p.name);
+                  const userServerGroups = groupByModelType(userServer, p => p.model_type, p => p.name);
+                  const browserGroups = groupByModelType(customPresets, p => p.config.model_type, p => p.name);
 
-                {serverPresets.filter(p => !p.is_builtin).length > 0 && (
-                  <>
+                  return (
+                    <>
+                      {builtins.length > 0 && (
+                        <>
+                          <div className="px-2 py-1.5 text-xs font-semibold text-purple-400">Built-in Presets</div>
+                          {sortedModelTypeKeys(builtinGroups).map(type => (
+                            <SelectGroup key={`builtin-${type}`}>
+                              <SelectLabel className="text-xs text-muted-foreground">{type}</SelectLabel>
+                              {builtinGroups.get(type)!.map(preset => (
+                                <SelectItem key={preset.id} value={preset.id}>
+                                  {preset.name}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          ))}
+                        </>
+                      )}
 
-                    <div className="px-2 py-1.5 text-xs font-semibold text-blue-400 mt-2">
-                      Your Server Presets
-                    </div>
-                    {serverPresets.filter(p => !p.is_builtin).map((preset) => (
-                      <SelectItem key={preset.id} value={preset.id}>
-                        <div className="flex items-center gap-2">
-                          <Badge variant="outline" className="text-xs">
-                            {preset.model_type}
-                          </Badge>
-                          {preset.name}
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </>
-                )}
+                      {userServer.length > 0 && (
+                        <>
+                          <div className="px-2 py-1.5 text-xs font-semibold text-blue-400 mt-2">Your Server Presets</div>
+                          {sortedModelTypeKeys(userServerGroups).map(type => (
+                            <SelectGroup key={`server-${type}`}>
+                              <SelectLabel className="text-xs text-muted-foreground">{type}</SelectLabel>
+                              {userServerGroups.get(type)!.map(preset => (
+                                <SelectItem key={preset.id} value={preset.id}>
+                                  {preset.name}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          ))}
+                        </>
+                      )}
 
-                {customPresets.length > 0 && (
-                  <>
-                    <div className="px-2 py-1.5 text-xs font-semibold text-cyan-400 mt-2">
-                      Browser-Only Presets
-                    </div>
-                    {customPresets.map((preset) => (
-                      <SelectItem key={preset.id} value={preset.id}>
-                        <div className="flex items-center gap-2">
-                          <Badge variant="outline" className="text-xs">
-                            {preset.config.model_type}
-                          </Badge>
-                          {preset.name}
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </>
-                )}
+                      {customPresets.length > 0 && (
+                        <>
+                          <div className="px-2 py-1.5 text-xs font-semibold text-cyan-400 mt-2">Browser-Only Presets</div>
+                          {sortedModelTypeKeys(browserGroups).map(type => (
+                            <SelectGroup key={`browser-${type}`}>
+                              <SelectLabel className="text-xs text-muted-foreground">{type}</SelectLabel>
+                              {browserGroups.get(type)!.map(preset => (
+                                <SelectItem key={preset.id} value={preset.id}>
+                                  {preset.name}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          ))}
+                        </>
+                      )}
+                    </>
+                  );
+                })()}
               </SelectContent>
             </Select>
 

--- a/frontend/components/training/PresetManager.tsx
+++ b/frontend/components/training/PresetManager.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/set-state-in-effect */
 'use client';
 
-import { useState, useEffect } from 'react';
+import { Fragment, useState, useEffect } from 'react';
 import { Save, FolderOpen, Trash2, Download, Upload, Sparkles } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -32,6 +32,10 @@ import { presetsAPI, type TrainingConfig, type PresetMetadata } from '@/lib/api'
 
 const MODEL_TYPE_ORDER = ['SD15', 'SDXL', 'FLUX', 'SD3', 'SD3.5', 'LUMINA', 'Chroma', 'Anima', 'HunyuanImage'];
 
+/**
+ * Group presets by model type, sorting each bucket alphabetically by name.
+ * Presets without a model type are placed under the 'Other' bucket.
+ */
 function groupByModelType<T>(presets: T[], getType: (p: T) => string | undefined, getName: (p: T) => string): Map<string, T[]> {
   const groups = new Map<string, T[]>();
   for (const preset of presets) {
@@ -45,6 +49,11 @@ function groupByModelType<T>(presets: T[], getType: (p: T) => string | undefined
   return groups;
 }
 
+/**
+ * Return model-type bucket keys in display order: types listed in MODEL_TYPE_ORDER
+ * first (preserving that order), then any remaining types (e.g. 'Other') sorted
+ * alphabetically.
+ */
 function sortedModelTypeKeys(groups: Map<string, unknown[]>): string[] {
   return [...groups.keys()].sort((a, b) => {
     const ai = MODEL_TYPE_ORDER.indexOf(a);
@@ -392,6 +401,12 @@ export default function PresetManager({
     reader.readAsText(file);
   };
 
+  const builtins = serverPresets.filter(p => p.is_builtin);
+  const userServer = serverPresets.filter(p => !p.is_builtin);
+  const builtinGroups = groupByModelType(builtins, p => p.model_type, p => p.name);
+  const userServerGroups = groupByModelType(userServer, p => p.model_type, p => p.name);
+  const browserGroups = groupByModelType(customPresets, p => p.config.model_type, p => p.name);
+
   return (
     <Card className="border-purple-500/30 bg-gradient-to-br from-purple-500/5 via-card to-card dark:from-purple-500/10 dark:via-card dark:to-card">
       <CardHeader>
@@ -413,65 +428,53 @@ export default function PresetManager({
                 <SelectValue placeholder="Choose a preset..." />
               </SelectTrigger>
               <SelectContent>
-                {(() => {
-                  const builtins = serverPresets.filter(p => p.is_builtin);
-                  const userServer = serverPresets.filter(p => !p.is_builtin);
-                  const builtinGroups = groupByModelType(builtins, p => p.model_type, p => p.name);
-                  const userServerGroups = groupByModelType(userServer, p => p.model_type, p => p.name);
-                  const browserGroups = groupByModelType(customPresets, p => p.config.model_type, p => p.name);
+                {builtins.length > 0 && (
+                  <SelectGroup>
+                    <SelectLabel className="font-semibold text-purple-400">Built-in Presets</SelectLabel>
+                    {sortedModelTypeKeys(builtinGroups).map(type => (
+                      <Fragment key={`builtin-${type}`}>
+                        <SelectLabel className="text-xs text-muted-foreground pl-4">{type}</SelectLabel>
+                        {builtinGroups.get(type)!.map(preset => (
+                          <SelectItem key={preset.id} value={preset.id}>
+                            {preset.name}
+                          </SelectItem>
+                        ))}
+                      </Fragment>
+                    ))}
+                  </SelectGroup>
+                )}
 
-                  return (
-                    <>
-                      {builtins.length > 0 && (
-                        <>
-                          <div className="px-2 py-1.5 text-xs font-semibold text-purple-400">Built-in Presets</div>
-                          {sortedModelTypeKeys(builtinGroups).map(type => (
-                            <SelectGroup key={`builtin-${type}`}>
-                              <SelectLabel className="text-xs text-muted-foreground">{type}</SelectLabel>
-                              {builtinGroups.get(type)!.map(preset => (
-                                <SelectItem key={preset.id} value={preset.id}>
-                                  {preset.name}
-                                </SelectItem>
-                              ))}
-                            </SelectGroup>
-                          ))}
-                        </>
-                      )}
+                {userServer.length > 0 && (
+                  <SelectGroup>
+                    <SelectLabel className="font-semibold text-blue-400">Your Server Presets</SelectLabel>
+                    {sortedModelTypeKeys(userServerGroups).map(type => (
+                      <Fragment key={`server-${type}`}>
+                        <SelectLabel className="text-xs text-muted-foreground pl-4">{type}</SelectLabel>
+                        {userServerGroups.get(type)!.map(preset => (
+                          <SelectItem key={preset.id} value={preset.id}>
+                            {preset.name}
+                          </SelectItem>
+                        ))}
+                      </Fragment>
+                    ))}
+                  </SelectGroup>
+                )}
 
-                      {userServer.length > 0 && (
-                        <>
-                          <div className="px-2 py-1.5 text-xs font-semibold text-blue-400 mt-2">Your Server Presets</div>
-                          {sortedModelTypeKeys(userServerGroups).map(type => (
-                            <SelectGroup key={`server-${type}`}>
-                              <SelectLabel className="text-xs text-muted-foreground">{type}</SelectLabel>
-                              {userServerGroups.get(type)!.map(preset => (
-                                <SelectItem key={preset.id} value={preset.id}>
-                                  {preset.name}
-                                </SelectItem>
-                              ))}
-                            </SelectGroup>
-                          ))}
-                        </>
-                      )}
-
-                      {customPresets.length > 0 && (
-                        <>
-                          <div className="px-2 py-1.5 text-xs font-semibold text-cyan-400 mt-2">Browser-Only Presets</div>
-                          {sortedModelTypeKeys(browserGroups).map(type => (
-                            <SelectGroup key={`browser-${type}`}>
-                              <SelectLabel className="text-xs text-muted-foreground">{type}</SelectLabel>
-                              {browserGroups.get(type)!.map(preset => (
-                                <SelectItem key={preset.id} value={preset.id}>
-                                  {preset.name}
-                                </SelectItem>
-                              ))}
-                            </SelectGroup>
-                          ))}
-                        </>
-                      )}
-                    </>
-                  );
-                })()}
+                {customPresets.length > 0 && (
+                  <SelectGroup>
+                    <SelectLabel className="font-semibold text-cyan-400">Browser-Only Presets</SelectLabel>
+                    {sortedModelTypeKeys(browserGroups).map(type => (
+                      <Fragment key={`browser-${type}`}>
+                        <SelectLabel className="text-xs text-muted-foreground pl-4">{type}</SelectLabel>
+                        {browserGroups.get(type)!.map(preset => (
+                          <SelectItem key={preset.id} value={preset.id}>
+                            {preset.name}
+                          </SelectItem>
+                        ))}
+                      </Fragment>
+                    ))}
+                  </SelectGroup>
+                )}
               </SelectContent>
             </Select>
 

--- a/frontend/lib/node-services/config-service.ts
+++ b/frontend/lib/node-services/config-service.ts
@@ -394,7 +394,9 @@ function getNetworkConfig(config: TrainingConfig): any {
 }
 
 /**
- * Map TrainingConfig to Kohya CLI argument keys
+ * Map TrainingConfig to a flat object of Kohya CLI argument keys suitable for
+ * serialisation as config.toml. Keys must match Kohya's argparse names exactly;
+ * unknown keys are silently ignored by Kohya's TOML loader.
  */
 function getTrainingArguments(config: TrainingConfig, projectRoot: string): any {
   // Model paths: HF IDs pass through, local paths resolve against projectRoot
@@ -558,7 +560,7 @@ function getTrainingArguments(config: TrainingConfig, projectRoot: string): any 
   const optimizerArgsList: string[] = [`weight_decay=${config.weight_decay ?? 0.01}`];
   if (config.optimizer_args) {
     // config.optimizer_args is a space-separated string from the UI
-    const extras = String(config.optimizer_args).trim().split(/\s+/).filter(Boolean);
+    const extras = config.optimizer_args.trim().split(/\s+/).filter(Boolean);
     // don't duplicate weight_decay if user already specified it
     for (const extra of extras) {
       if (!extra.startsWith('weight_decay=')) optimizerArgsList.push(extra);

--- a/frontend/lib/node-services/config-service.ts
+++ b/frontend/lib/node-services/config-service.ts
@@ -408,16 +408,16 @@ function getTrainingArguments(config: TrainingConfig, projectRoot: string): any 
     output_dir: rpLocal(config.output_dir),
     output_name: config.output_name,
     seed: config.seed,
+    learning_rate: config.unet_lr,
     unet_lr: config.unet_lr,
     text_encoder_lr: config.text_encoder_lr,
     lr_scheduler: config.lr_scheduler,
     lr_scheduler_num_cycles: config.lr_scheduler_number,
-    lr_warmup_ratio: config.lr_warmup_ratio,
-    lr_warmup_steps: config.lr_warmup_steps,
-    lr_power: config.lr_power,
+    // lr_warmup_steps accepts int (steps) or float <1 (ratio) — use ratio when steps not explicitly set
+    lr_warmup_steps: config.lr_warmup_steps > 0 ? config.lr_warmup_steps : config.lr_warmup_ratio,
+    lr_scheduler_power: config.lr_power,
     optimizer_type: config.optimizer_type,
     max_grad_norm: config.max_grad_norm,
-    weight_decay: config.weight_decay,
     max_token_length: config.max_token_length,
     weighted_captions: config.weighted_captions,
     no_token_padding: config.no_token_padding,
@@ -553,9 +553,18 @@ function getTrainingArguments(config: TrainingConfig, projectRoot: string): any 
   if (config.log_prefix) {
     args.log_prefix = config.log_prefix;
   }
+  // Build optimizer_args array: weight_decay always first, then any user extras.
+  // Kohya expects an array of "key=value" strings for --optimizer_args.
+  const optimizerArgsList: string[] = [`weight_decay=${config.weight_decay ?? 0.01}`];
   if (config.optimizer_args) {
-    args.optimizer_args = config.optimizer_args;
+    // config.optimizer_args is a space-separated string from the UI
+    const extras = String(config.optimizer_args).trim().split(/\s+/).filter(Boolean);
+    // don't duplicate weight_decay if user already specified it
+    for (const extra of extras) {
+      if (!extra.startsWith('weight_decay=')) optimizerArgsList.push(extra);
+    }
   }
+  args.optimizer_args = optimizerArgsList;
 
   // Steps vs Epochs handling
   if (config.max_train_steps && config.max_train_steps > 0) {


### PR DESCRIPTION
## Summary

- **Missing `learning_rate`**: Was never passed in TOML so Kohya silently used its argparse default of `2e-6` instead of the user's `unet_lr`. Now explicitly set to `unet_lr` so `ss_learning_rate` metadata is correct and optimizer fallback paths use the right value.
- **`lr_power` → `lr_scheduler_power`**: Wrong key name meant polynomial scheduler power was silently ignored (Kohya always used its default of 1).
- **`lr_warmup_ratio` never applied**: Was sent as an unknown key Kohya ignored. Now correctly mapped to `lr_warmup_steps` as a float (Kohya's `int_or_float` arg treats floats <1 as ratios).
- **`weight_decay` silently ignored**: Was sent as a top-level arg that doesn't exist in Kohya's argparse. Moved into the `optimizer_args` array (`["weight_decay=X", ...]`) where Kohya actually reads it.
- **`optimizer_args` string→array bug**: If a user had set optimizer args, passing a raw string to a `nargs='+'` arg would have iterated character-by-character. Now correctly split into a `string[]`.
- **Preset list sorted by model type**: Dropdown now groups presets under `SelectGroup`/`SelectLabel` sub-headers (SD15 → SDXL → FLUX → SD3 → SD3.5 → LUMINA → Chroma → Anima → HunyuanImage), alphabetical by name within each group.

## Test plan

- [ ] Train a run and verify `ss_learning_rate` in output LoRA metadata matches `unet_lr`
- [ ] Confirm polynomial scheduler respects the power setting
- [ ] Confirm warmup ratio applies correctly when warmup steps left at 0
- [ ] Check optimizer logs show correct `weight_decay` value
- [ ] Open preset dropdown and verify model-type grouping and alphabetical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preset options in the training interface are now organized by model type for improved navigation and selection.

* **Bug Fixes**
  * Updated training configuration handling for learning rate scheduling and weight decay parameters to ensure correct parameter processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/pull/371)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->