### PR TITLE
fix: guard training monitor against null lr/loss from Python Optional fields

### DIFF
--- a/BETA_PLANNING.md
+++ b/BETA_PLANNING.md
@@ -794,14 +794,25 @@ Fixes needed in priority order:
 2. **tqdm line parser** (UI-5) — surface step count, ETA, it/s in the monitor
 3. **Training monitor reconnect** — if the monitor component dies, user should be able to re-attach to a running job by job ID without refreshing the whole page
 
-### Calculator Enhancement — Optimizer-Aware Time Estimation
-The step calculator currently uses basic Kohya math. Proposal: make it optimizer-aware so it can give rough time estimates based on:
-- Optimizer choice (Adafactor is slower per step than AdamW8bit, Prodigy is variable)
-- Dataset size × repeats × epochs → total steps
-- Batch size effect on step count
+### Calculator Enhancement — Optimizer + LR Aware Step Guidance
+The step calculator currently uses basic Kohya math. Proposal: make it optimizer- and LR-aware so it gives rough but useful guidance on target step counts:
+
+**LR → steps relationship (the big one):**
+- LR and step count are in direct tension: higher LR = more work per step = fewer steps needed to reach convergence
+- The calculator should take LR as an input and adjust recommended steps/epochs accordingly
+- This is more impactful than optimizer choice — LR drives the curve, optimizer affects how cleanly you ride it
+
+**Optimizer adjustment (rough, vibes-based until we have more data):**
+- AdamW8bit: baseline (1.0x)
+- CAME: converges faster and burns in more aggressively — approx 0.6–0.7x steps for equivalent result; small datasets especially vulnerable to overtrain
+- Adafactor (fixed LR): slower per step, more conservative — approx 1.2–1.3x
+- Prodigy/DAdaptation: self-adjusting LR so step count guidance is less applicable
+
+**Other inputs already planned:**
+- Dataset size × repeats × batch size → total steps
 - Resolution effect on VRAM and speed
 
-Not exact science but "rough estimate with caveats" is infinitely more useful than nothing. Would have saved a lot of "is this an all-nighter?" uncertainty today.
+Not exact science — label everything as "rough guide." Even a "CAME + small dataset: consider reducing epochs by 30%" hint would have saved two undertrained LoRAs. Discovered from real training runs May 2026.
 
 ### Hardcoded Presets Migration (section 7.9)
 High priority — confirmed blocks training silently. Migrate all presets from `useTrainingForm.ts` into proper JSON files in `presets/`. This fixes the silent training failure AND the PR-1 optimizer_args contamination in one shot.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,18 @@ This file adds Claude Code-specific guidance on top of that foundation.
 
 Please keep all training presets out of the Next.js/TypeScript codebase. Instead, manage them exclusively through the JSON files in the presets/ folder. This keeps configuration centralized, simplifies version tracking, and avoids the inconsistencies that come with localStorage or hardcoded values.
 
+### Python Optional → Frontend Guard Rule
+
+Any time a Python field is typed `Optional[X]` (i.e. can be `null` in JSON), the corresponding frontend guards **must** use `!= null` (loose inequality), not `!== undefined`. JSON never produces `undefined` — only `null` — so `!== undefined` always passes on a null value and any method call (`.toFixed()`, `.toExponential()`, etc.) will throw at runtime.
+
+**Checklist when adding or changing an `Optional` field on the Python side:**
+1. Find the `api.ts` transformer that maps it into the frontend object.
+2. Find any render guards in components that check before displaying it.
+3. Find any state-merge guards (e.g. spread patterns) that use it.
+4. Change all three from `!== undefined` → `!= null`.
+
+This was learned from a `lr` / `loss` null crash in `TrainingMonitor.tsx` (PR b8c6c3d).
+
 ### Comments and Docstrings
 
 Prefer self-documenting code through clear naming. Avoid inline comments unless explaining a non-obvious rationale (edge cases, constraints, or workarounds). 

--- a/frontend/app/dataset/[name]/auto-tag/page.tsx
+++ b/frontend/app/dataset/[name]/auto-tag/page.tsx
@@ -208,7 +208,7 @@ export default function AutoTagPage() {
         if (data.type === 'log' && data.log) {
           const msg = data.log;
           setLogs(prev => { const next = [...prev, msg]; return next.length > MAX_LOGS ? next.slice(-MAX_LOGS) : next; });
-        } else if (data.type === 'progress' && data.progress !== undefined) {
+        } else if (data.type === 'progress' && data.progress != null) {
           setProgress(data.progress as number);
         } else if (data.type === 'status') {
           if (data.status === 'completed') addLog('✅ Tagging completed!');
@@ -321,7 +321,7 @@ export default function AutoTagPage() {
               if (data.type === 'log' && data.log) {
                 const msg = data.log;
                 setLogs(prev => { const next = [...prev, msg]; return next.length > MAX_LOGS ? next.slice(-MAX_LOGS) : next; });
-              } else if (data.type === 'progress' && data.progress !== undefined) {
+              } else if (data.type === 'progress' && data.progress != null) {
                 setProgress(data.progress as number);
               }
             },

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -250,7 +250,7 @@ export default function TrainingMonitor() {
       return h > 0 ? `~${h}h ${m}m` : `~${m}m`;
     }
 
-    if (!current_step || !total_steps) return 'Unknown';
+    if (current_step == null || total_steps == null || total_steps === 0) return 'Unknown';
     const stepsRemaining = total_steps - current_step;
     const estimatedMinutes = Math.ceil(stepsRemaining * 0.1);
     if (estimatedMinutes < 60) return `~${estimatedMinutes}m`;

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -225,7 +225,7 @@ export default function TrainingMonitor() {
   const getProgress = () => {
     if (!status.progress) return 0;
     // Use progress_percent from Python backend if available
-    if (status.progress.progress_percent !== undefined) return status.progress.progress_percent;
+    if (status.progress.progress_percent != null) return status.progress.progress_percent;
     // Fallback: calculate from step/total
     const { current_step, total_steps } = status.progress;
     if (!current_step || !total_steps) return 0;
@@ -237,7 +237,7 @@ export default function TrainingMonitor() {
     const { eta_seconds, current_step, total_steps } = status.progress as any;
 
     // Use tqdm's parsed ETA if available — it's far more accurate than our estimate
-    if (eta_seconds !== undefined && eta_seconds !== null) {
+    if (eta_seconds != null) {
       if (eta_seconds < 60) return `~${eta_seconds}s`;
       const h = Math.floor(eta_seconds / 3600);
       const m = Math.floor((eta_seconds % 3600) / 60);

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -14,7 +14,8 @@ interface TrainingStatus {
     total_epochs?: number;
     loss?: number;
     lr?: number;
-    progress_percent?: number;  // 0-100 from Python backend
+    eta_seconds?: number;
+    progress_percent?: number;
   };
 }
 
@@ -65,7 +66,7 @@ export default function TrainingMonitor() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const handleTrainingStart = (event: any) => {
+    const handleTrainingStart = (event: CustomEvent<{ jobId?: string }>) => {
       const newJobId = event.detail?.jobId || localStorage.getItem('current_training_job_id');
       if (newJobId) {
         console.log(`TrainingMonitor: received training-started event for ${newJobId}`);
@@ -159,7 +160,7 @@ export default function TrainingMonitor() {
             const next = [...prev, msg];
             return next.length > MAX_LOGS ? next.slice(-MAX_LOGS) : next;
           });
-        } else if (data.type === 'progress' && data.progress !== undefined) {
+        } else if (data.type === 'progress' && data.progress != null) {
           setStatus((prev) => ({
             ...prev,
             progress: {
@@ -188,7 +189,7 @@ export default function TrainingMonitor() {
             setConnected(false);
             localStorage.removeItem('current_training_job_id');
           } else if (data.status === 'failed') {
-            const errorMsg = (data as any).error || 'Unknown error';
+            const errorMsg = typeof data['error'] === 'string' ? data['error'] : 'Unknown error';
             setStatus({ is_training: false, error: errorMsg });
             setLogs((prev) => [...prev, `--- Training FAILED: ${errorMsg} ---`]);
             setConnected(false);
@@ -230,18 +231,16 @@ export default function TrainingMonitor() {
   /** Returns 0–100 progress percentage, preferring the backend-parsed value over the step-based estimate. */
   const getProgress = () => {
     if (!status.progress) return 0;
-    // Use progress_percent from Python backend if available
     if (status.progress.progress_percent != null) return status.progress.progress_percent;
-    // Fallback: calculate from step/total
     const { current_step, total_steps } = status.progress;
-    if (!current_step || !total_steps) return 0;
+    if (current_step == null || total_steps == null || total_steps === 0) return 0;
     return (current_step / total_steps) * 100;
   };
 
   /** Returns a human-readable ETA string, preferring tqdm's parsed eta_seconds over a rough step-based estimate. */
   const getTimeRemaining = () => {
     if (!status.progress) return 'Calculating...';
-    const { eta_seconds, current_step, total_steps } = status.progress as any;
+    const { eta_seconds, current_step, total_steps } = status.progress;
 
     // Use tqdm's parsed ETA if available — it's far more accurate than our estimate
     if (eta_seconds != null) {
@@ -359,7 +358,7 @@ export default function TrainingMonitor() {
           </span>
         </div>
 
-        <div className="bg-background  p-4 font-mono text-sm text-green-400 h-96 overflow-y-auto">
+        <div className="bg-background p-4 font-mono text-sm text-green-400 h-96 overflow-y-auto">
           {logs.length === 0 ? (
             <div className="text-muted-foreground text-center py-8">
               {status.is_training

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -306,7 +306,7 @@ export default function TrainingMonitor() {
           </div>
 
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {status.progress.current_epoch !== undefined && (
+            {status.progress.current_epoch != null && (
               <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-3">
                 <div className="flex items-center gap-2 text-blue-400 mb-1">
                   <TrendingUp className="w-4 h-4" />

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -167,13 +167,13 @@ export default function TrainingMonitor() {
             ...prev,
             progress: {
               ...prev.progress,
-              ...(data.step_num !== undefined && { current_step: data.step_num }),
-              ...(data.total_steps !== undefined && { total_steps: data.total_steps }),
-              ...(data.current_epoch !== undefined && { current_epoch: data.current_epoch }),
-              ...(data.total_epochs !== undefined && { total_epochs: data.total_epochs }),
-              ...(data.loss !== undefined && { loss: data.loss }),
-              ...(data.lr !== undefined && { lr: data.lr }),
-              ...(data.eta_seconds !== undefined && { eta_seconds: data.eta_seconds }),
+              ...(data.step_num != null && { current_step: data.step_num }),
+              ...(data.total_steps != null && { total_steps: data.total_steps }),
+              ...(data.current_epoch != null && { current_epoch: data.current_epoch }),
+              ...(data.total_epochs != null && { total_epochs: data.total_epochs }),
+              ...(data.loss != null && { loss: data.loss }),
+              ...(data.lr != null && { lr: data.lr }),
+              ...(data.eta_seconds != null && { eta_seconds: data.eta_seconds }),
             },
           }));
         } else if (data.type === 'status') {
@@ -310,7 +310,7 @@ export default function TrainingMonitor() {
                 </div>
               </div>
             )}
-            {status.progress.lr !== undefined && (
+            {status.progress.lr != null && (
               <div className="bg-purple-500/10 border border-purple-500/30 rounded-lg p-3">
                 <div className="flex items-center gap-2 text-purple-400 mb-1">
                   <Zap className="w-4 h-4" />
@@ -321,7 +321,7 @@ export default function TrainingMonitor() {
                 </div>
               </div>
             )}
-            {status.progress.loss !== undefined && (
+            {status.progress.loss != null && (
               <div className="bg-green-500/10 border border-green-500/30 rounded-lg p-3">
                 <div className="flex items-center gap-2 text-green-400 mb-1">
                   <Activity className="w-4 h-4" />

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -18,6 +18,11 @@ interface TrainingStatus {
   };
 }
 
+/**
+ * Real-time training monitor that polls job status and streams logs.
+ * Uses HTTP polling instead of WebSockets to survive Caddy proxy disconnects.
+ * Job ID is sourced from the `?job=` query param or localStorage fallback.
+ */
 export default function TrainingMonitor() {
   const [status, setStatus] = useState<TrainingStatus>({ is_training: false });
   const [logs, setLogs] = useState<string[]>([]);
@@ -222,6 +227,7 @@ export default function TrainingMonitor() {
     };
   }, [status.is_training, jobId]);
 
+  /** Returns 0–100 progress percentage, preferring the backend-parsed value over the step-based estimate. */
   const getProgress = () => {
     if (!status.progress) return 0;
     // Use progress_percent from Python backend if available
@@ -232,6 +238,7 @@ export default function TrainingMonitor() {
     return (current_step / total_steps) * 100;
   };
 
+  /** Returns a human-readable ETA string, preferring tqdm's parsed eta_seconds over a rough step-based estimate. */
   const getTimeRemaining = () => {
     if (!status.progress) return 'Calculating...';
     const { eta_seconds, current_step, total_steps } = status.progress as any;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -900,13 +900,13 @@ export const trainingAPI = {
           // Forward step/loss/lr/eta parsed from tqdm so the monitor stats update
           // on every log poll (1s cadence) rather than waiting for the 2s status poll.
           if (
-            data.step_num !== undefined ||
-            data.total_steps !== undefined ||
-            data.current_epoch !== undefined ||
-            data.total_epochs !== undefined ||
-            data.loss !== undefined ||
-            data.lr !== undefined ||
-            data.eta_seconds !== undefined
+            data.step_num != null ||
+            data.total_steps != null ||
+            data.current_epoch != null ||
+            data.total_epochs != null ||
+            data.loss != null ||
+            data.lr != null ||
+            data.eta_seconds != null
           ) {
             onMessage({
               type: 'step_progress',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -490,7 +490,7 @@ export const datasetAPI = {
         }
       },
       (status, progress) => {
-        if (progress !== undefined) {
+        if (progress != null) {
           onMessage({ type: 'progress', progress });
         }
         onMessage({ type: 'status', status });
@@ -575,7 +575,7 @@ export const captioningAPI = {
         }
       },
       (status, progress) => {
-        if (progress !== undefined) {
+        if (progress != null) {
           onMessage({ type: 'progress', progress });
         }
         onMessage({ type: 'status', status });
@@ -894,7 +894,7 @@ export const trainingAPI = {
 
         // Report status and progress
         if (data.status) {
-          if (data.progress !== undefined) {
+          if (data.progress != null) {
             onMessage({ type: 'progress', progress: data.progress });
           }
           // Forward step/loss/lr/eta parsed from tqdm so the monitor stats update


### PR DESCRIPTION
## Summary

- `frontend/lib/api.ts` — don't emit `step_progress` when all tqdm fields are null (previously fired every poll due to `null !== undefined` being `true`)
- `frontend/components/training/TrainingMonitor.tsx` — state-merge guards changed to `!= null` so a null update can't clobber a previously-good `lr`/`loss` value
- `frontend/components/training/TrainingMonitor.tsx` — render guards changed to `!= null` so `.toExponential()`/`.toFixed()` are never called on null
- `CLAUDE.md` — documents the Python `Optional` → `!= null` rule with checklist to prevent recurrence

## Root cause

Python `Optional[float]` serialises as JSON `null`. JS `null !== undefined` evaluates to `true`, so every `!== undefined` guard in the chain passed on null values. On every status poll (~1s cadence) the training monitor called `null.toExponential(2)` and threw, flooding the app log with the same error repeatedly.

Reported via Drgracey's app log (`app_20260511.log`).

## Test plan
- [ ] Start a training run and verify the training monitor stats panel renders without console errors
- [ ] Confirm LR and Loss cards appear only once the tqdm parser starts producing real values (not on first poll)
- [ ] Verify no `TypeError: Cannot read properties of null` errors in browser console during training

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Training monitor now reliably shows progress, step/epoch counts, loss, learning rate, and ETA when backend provides those values (handles nullable fields correctly).

* **Documentation**
  * Added guidance to treat optional JSON fields as nullable (use != null checks) with a checklist for updating related guards/transformers.
  * Updated planning notes to provide optimizer- and LR-aware step/epoch guidance as a rough estimate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/pull/373)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->