### PR TITLE
fix: address reflow violations in TrainingMonitor and auto-tag page (#374)

### DIFF
--- a/BETA_PLANNING.md
+++ b/BETA_PLANNING.md
@@ -890,8 +890,8 @@ The goal is a healthy, interconnected set of tools running on the same VastAI/Ru
 ### 11.1 ComfyUI Frontend Integration
 
 **Priority:** Beta+ (after core beta bugs closed)  
-**Status:** Template acquired, architecture planned. **Shipping decision: all-in-one.**
-**Source:** v0-generated template, repo at `duskfallcrew/KNX-ComfyUI`, to be adapted — not dropped in wholesale
+**Status:** Architecture finalised 2026-05-20. **Shipping decision: all-in-one.**
+**Source:** v0-generated template, repo at `duskfallcrew/KNX-ComfyUI`, used as reference — not dropped in wholesale. Code lives in the main trainer repo.
 
 #### Shipping decision (2026-05-09)
 
@@ -908,7 +908,44 @@ ComfyUI tab ships **bundled in the main app**. No install flag, no optional clon
 - Settings page has a "ComfyUI URL" field (default: `http://localhost:8188`) so users who already have ComfyUI running somewhere can point the app at it — no re-install needed
 - Connection status badge on the tab so it's obvious at a glance whether it's live
 
+#### ComfyUI backend: submodule (2026-05-20)
 
+ComfyUI the Python backend ships as a **git submodule** in the trainer repo. It runs co-located on `localhost:8188` — always same machine, no SSH, no remote ComfyUI. Multi-GPU / remote-ComfyUI is explicitly future scope.
+
+Provisioning scripts (`vastai_setup.sh`, `provision_runpod.sh`, `install.bat`) do `git submodule update --init --recursive` to pull it down and start it alongside FastAPI and Next.js. The frontend tab is always present; the disconnected skeleton state covers the case where the user hasn't initialised the submodule yet.
+
+#### Workflow state architecture: B2 (2026-05-20)
+
+We wrap ComfyUI's API — we do not re-implement node logic. Source of truth is always ComfyUI.
+
+**Chosen approach (B2 — workflow-aware template mapping):**
+- Ship known workflow templates: each template = `workflow.json` + `node-map.json` (node type → UI control binding)
+- Templates live in `frontend/comfy/workflows/` — same spirit as `presets/`
+- On connect: load the active template's node map; bind UI controls to node types (not node IDs — IDs shift, types don't)
+- On generate: inject current UI values into the template JSON → `POST /comfy/prompt`
+- On result: poll `/comfy/history` for output images
+
+**Why not full live-graph reading (B1) yet:** B2 is the right starting point. B1 (reading every node dynamically via `/object_info`) is the long-horizon evolution as the node library grows — the architecture doesn't close that door, it just doesn't require it on day one.
+
+**Architecture switcher (ANIMA ↔ SDXL):**
+- Switcher in the UI header swaps which template is loaded — same resizable-panel UI, different workflow JSON + node map underneath
+- ANIMA template is first (reference: `guy90sVerySimpleAndEasyTo_v10.json`, tested and verified 2026-05-19 — AuraFlow model sampling node, UNET/CLIP/VAE separate loaders, KSampler, Adetailer, Ultimate SD Upscale)
+- SDXL template is the second built-in; in progress, not blocking ANIMA shipping
+
+**Extension model:**
+- Community contributions come in two forms: **workflow templates** (new architecture support) and **node packages** (new node type → UI control bindings)
+- Both drop into `frontend/comfy/workflows/` — no app code changes needed to add a new architecture
+- This is the same philosophy as `presets/` and maps to ComfyUI's own custom node ecosystem
+
+**LoRA Manager integration:**
+- The LoRA Manager custom node (`Lora Loader (LoraManager)`) ships with guy90s's workflow and provides a browseable popup UI for LoRA selection
+- Our UI has a **LoRA Manager button** — clicking it opens ComfyUI's LoRA Manager in a new browser tab (A1111-style "open extra networks" pattern)
+- LoRA selection state reads back from live workflow via the proxy — no separate sync needed
+
+**Node presence check:**
+- On connect, `GET /comfy/object_info` returns all loaded node types
+- Soft-check: if a node type required by the active template is missing, surface a friendly warning ("This workflow requires LoRA Manager — install it via ComfyUI Manager")
+- We do NOT auto-install nodes. Users manage their own ComfyUI custom nodes for now.
 
 #### What the template provides
 
@@ -966,9 +1003,10 @@ The client defaults to `http://localhost:8188` and opens a WebSocket directly fr
 - Requires: COMFY-1 through COMFY-4 complete + ComfyUI actually running on the instance
 
 #### Notes
-- ComfyUI the **backend** is not bundled — the user installs and runs it separately. The frontend tab is always present; it shows a disconnected skeleton state if the backend isn't reachable. The provisioning scripts (`vastai_setup.sh`, `provision_runpod.sh`) may optionally install it, but that's a separate decision.
+- ComfyUI backend ships as a **git submodule**, always co-located, `localhost:8188`. See "ComfyUI backend: submodule" section above.
 - The template has workflow builders for `inpaint`, `controlnet`, and `adetailer` types referenced in `types.ts` but not yet built in `workflows/`. Those are future scope.
 - Check whether `zustand` is already a dep before adding it — the stores use it.
+- **Issue #374 (Reflow Violations)** is a separate track from ComfyUI work — do not conflate. Fix reflow violations in the existing trainer pages independently.
 
 ---
 

--- a/BETA_PLANNING.md
+++ b/BETA_PLANNING.md
@@ -575,9 +575,9 @@ The `[elapsed<remaining, it/s]` is all the data we need but we currently pass lo
 | Respect enable_bucket user setting (LT-2) | Bug Fix | Tiny | ✅ Done 2026-04-30 |
 | LyCORIS algorithm-specific validation (LT-5) | Enhancement | Medium | ⏳ Not started |
 | Clarify "Full" LoRA type semantics (LT-4) | UX | Small | ⏳ Not started |
-| Silence AbortError console noise (UI-3) | Polish | Small | ⏳ Not started |
+| Silence AbortError console noise (UI-3) | Polish | Small | ✅ Done 2026-05-20 |
 | Fix training log polling cadence + visibility (UI-4) | UX/Bug Fix | Small | ✅ Done 2026-04-30 |
-| Add PYTHONUNBUFFERED to Kohya subprocess (UI-4 part) | Bug Fix | Tiny | ⏳ Next session |
+| Add PYTHONUNBUFFERED to Kohya subprocess (UI-4 part) | Bug Fix | Tiny | ✅ Done (via -u flag in kohya.py:124) |
 | MG-2: Document save_precision naming difference | Code Clarity | Tiny | ✅ Done 2026-04-30 |
 
 ### Nice to Have (Beta+)
@@ -839,6 +839,26 @@ The following features were inspired by Civitai's training interface:
 
 ## 9. Session Notes
 
+### 2026-05-20 — Reflow Fixes + Log Stream Cutout + ComfyUI Planning
+
+**Completed this session:**
+- **PR #375** — Reflow violations (#374): TrainingMonitor auto-scroll fully deferred into rAF with cancelAnimationFrame on cleanup; auto-tag SelectContent → `position="item-aligned"` (removes Floating UI getBoundingClientRect on mousedown); 4 raw `<button>` elements → shadcn `<Button>`; `MAX_LOGS` 1000→500; `aria-label`, `gap-2`, `type="button"` added per CodeRabbit review.
+- **PR #376** — Log stream cutout bug: `Job.logs` is a `deque(maxlen=1000)`. Once full, `get_logs(since)` always returned `[]` because it used a buffer-relative index — `since` reached `maxlen` and `start >= len(logs)` was permanently true. Root cause of the 5-7 minute log cutout on a 4090. Fixed with `total_lines_written` absolute counter; same bug fixed in `stream_logs` WebSocket path. `deque` maxlen raised to 2000. 13 regression tests added.
+- **BETA_PLANNING.md §11.1** — ComfyUI architecture finalised: submodule approach, B2 workflow-template state model, extension system (workflow templates + node packages), LoRA Manager button → new tab, ANIMA ↔ SDXL switcher.
+- **UI-3** confirmed done — AbortError caught and suppressed in both `pollLogs` paths in `api.ts`.
+- **UI-4 PYTHONUNBUFFERED** confirmed done — achieved via `-u` flag in `kohya.py:124`.
+
+**Status check findings:**
+- PR-0 (OptimizerSchema single source of truth) — still genuinely pending. No `OPTIMIZER_VALUES as const` in `validation.ts`.
+- LT-1 + UI-1 (WandB logging UI) — still pending.
+
+**Up next:**
+- Merge PR #375 (reflow) → PR #376 (log stream) onto main
+- LT-1 + UI-1 (#343): WandB key env var + LoggingCard
+- PR-0: Export OPTIMIZER_VALUES/LRSCHEDULER_VALUES as `as const` from validation.ts
+
+---
+
 ### 2026-04-30 — Beta Bug Bash
 
 **Completed this session (commits on `dev`):**
@@ -1006,7 +1026,7 @@ The client defaults to `http://localhost:8188` and opens a WebSocket directly fr
 - ComfyUI backend ships as a **git submodule**, always co-located, `localhost:8188`. See "ComfyUI backend: submodule" section above.
 - The template has workflow builders for `inpaint`, `controlnet`, and `adetailer` types referenced in `types.ts` but not yet built in `workflows/`. Those are future scope.
 - Check whether `zustand` is already a dep before adding it — the stores use it.
-- **Issue #374 (Reflow Violations)** is a separate track from ComfyUI work — do not conflate. Fix reflow violations in the existing trainer pages independently.
+- **Issue #374 (Reflow Violations)** fixed in PR #375 (2026-05-20). TrainingMonitor auto-scroll moved fully into rAF with cleanup; auto-tag page SelectContent → position="item-aligned"; raw buttons → shadcn Button.
 
 ---
 

--- a/frontend/app/dataset/[name]/auto-tag/page.tsx
+++ b/frontend/app/dataset/[name]/auto-tag/page.tsx
@@ -1030,13 +1030,16 @@ export default function AutoTagPage() {
                 </div>
 
                 {/* Advanced Options Toggle */}
-                <button
+                <Button
+                  type="button"
+                  variant="ghost"
                   onClick={() => setShowAdvanced(!showAdvanced)}
-                  className="w-full px-4 py-2 bg-accent hover:bg-accent/80 rounded-lg flex items-center justify-between"
+                  aria-expanded={showAdvanced}
+                  className="w-full justify-between px-4"
                 >
                   <span className="text-sm font-medium">Advanced Options</span>
                   {showAdvanced ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-                </button>
+                </Button>
 
                 {showAdvanced && (
                   <div className="space-y-2 pt-2 border-t border-border">
@@ -1078,7 +1081,7 @@ export default function AutoTagPage() {
                   <Button
                     onClick={handleStartTagging}
                     disabled={tagging || !selectedDataset || datasets.length === 0}
-                    className="flex-1"
+                    className="flex-1 gap-2"
                   >
                     <Play className="w-5 h-5" />
                     {tagging ? 'Tagging...' : 'Start'}
@@ -1087,6 +1090,7 @@ export default function AutoTagPage() {
                     <Button
                       onClick={handleStopTagging}
                       variant="destructive"
+                      className="gap-2"
                     >
                       <Square className="w-5 h-5" />
                       Stop
@@ -1173,6 +1177,7 @@ export default function AutoTagPage() {
                     size="icon"
                     onClick={() => setLogs([])}
                     className="mr-2"
+                    aria-label="Clear logs"
                   >
                     <X className="w-4 h-4" />
                   </Button>

--- a/frontend/app/dataset/[name]/auto-tag/page.tsx
+++ b/frontend/app/dataset/[name]/auto-tag/page.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, SelectGroup, SelectLabel } from '@/components/ui/select';
 
 // Unified model definitions
@@ -410,7 +411,7 @@ export default function AutoTagPage() {
                       <SelectTrigger className="w-full">
                         <SelectValue placeholder="Select dataset..." />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent position="item-aligned">
                         {datasets.map(ds => (
                           <SelectItem key={ds.path} value={ds.path}>
                             {ds.name} ({ds.image_count} images)
@@ -428,7 +429,7 @@ export default function AutoTagPage() {
                     <SelectTrigger className="w-full">
                       <SelectValue placeholder="Select model..." />
                     </SelectTrigger>
-                    <SelectContent>
+                    <SelectContent position="item-aligned">
                       <SelectGroup>
                         <SelectLabel>WD14 Tagger (Anime Tags)</SelectLabel>
                         {AVAILABLE_MODELS.filter(m => m.type === 'wd14').map(model => (
@@ -469,7 +470,7 @@ export default function AutoTagPage() {
                     <SelectTrigger className="w-full">
                       <SelectValue placeholder="Select extension..." />
                     </SelectTrigger>
-                    <SelectContent>
+                    <SelectContent position="item-aligned">
                       <SelectItem value=".txt">.txt (Kohya standard)</SelectItem>
                       <SelectItem value=".caption">.caption</SelectItem>
                       <SelectItem value=".cap">.cap</SelectItem>
@@ -1074,26 +1075,22 @@ export default function AutoTagPage() {
             <Card>
               <CardContent className="pt-6 space-y-4">
                 <div className="flex gap-3">
-                  <button
+                  <Button
                     onClick={handleStartTagging}
                     disabled={tagging || !selectedDataset || datasets.length === 0}
-                    className={`flex-1 px-6 py-3 ${
-                      tagging || !selectedDataset || datasets.length === 0
-                        ? 'bg-muted !text-muted-foreground cursor-not-allowed opacity-60 border-2 border-border'
-                        : 'bg-gradient-to-r from-pink-500 to-rose-500 hover:from-pink-600 hover:to-rose-600 !text-white shadow-lg'
-                    } rounded-lg font-semibold flex items-center justify-center gap-2`}
+                    className="flex-1"
                   >
                     <Play className="w-5 h-5" />
                     {tagging ? 'Tagging...' : 'Start'}
-                  </button>
+                  </Button>
                   {tagging && (
-                    <button
+                    <Button
                       onClick={handleStopTagging}
-                      className="px-6 py-3 bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white rounded-lg font-semibold shadow-lg flex items-center justify-center gap-2"
+                      variant="destructive"
                     >
                       <Square className="w-5 h-5" />
                       Stop
-                    </button>
+                    </Button>
                   )}
                 </div>
 
@@ -1157,25 +1154,28 @@ export default function AutoTagPage() {
           <div className="mt-6">
             <div className="bg-card border border-border rounded-lg overflow-hidden">
               <div className="flex items-center bg-accent/50 hover:bg-accent">
-                <button
+                <Button
+                  variant="ghost"
                   onClick={() => setLogsExpanded(v => !v)}
                   aria-expanded={logsExpanded}
                   aria-controls="auto-tag-logs-body"
-                  className="flex-1 px-6 py-4 flex items-center justify-between"
+                  className="flex-1 px-6 py-4 justify-between h-auto"
                 >
                   <div className="flex items-center gap-2 font-semibold">
                     <Terminal className="w-5 h-5" />
                     Process Logs {jobId && <span className="text-xs text-muted-foreground">({jobId})</span>}
                   </div>
                   {logsExpanded ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
-                </button>
+                </Button>
                 {logs.length > 0 && (
-                  <button
+                  <Button
+                    variant="ghost"
+                    size="icon"
                     onClick={() => setLogs([])}
-                    className="p-1 mr-4 hover:bg-accent-foreground/10 rounded"
+                    className="mr-2"
                   >
                     <X className="w-4 h-4" />
-                  </button>
+                  </Button>
                 )}
               </div>
               {logsExpanded && (

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -52,18 +52,20 @@ export default function TrainingMonitor() {
   const isTrainingRef = useRef(status.is_training);
   isTrainingRef.current = status.is_training;
 
-  // Auto-scroll only when the user is already near the bottom, deferred via
-  // requestAnimationFrame so it runs outside React's commit phase and avoids
-  // forcing a synchronous layout recalc on every log update.
+  // Auto-scroll only when the user is already near the bottom.
+  // Both the layout reads and scrollIntoView are deferred into rAF so nothing
+  // touches layout synchronously in the useEffect body. The rAF is cancelled
+  // on cleanup to prevent reads/writes against an unmounted container.
   useEffect(() => {
-    const container = logContainerRef.current;
-    if (!container) return;
-    const { scrollTop, scrollHeight, clientHeight } = container;
-    if (scrollHeight - scrollTop - clientHeight < 120) {
-      requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
+      const container = logContainerRef.current;
+      if (!container) return;
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      if (scrollHeight - scrollTop - clientHeight < 120) {
         logsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-      });
-    }
+      }
+    });
+    return () => cancelAnimationFrame(rafId);
   }, [logs]);
 
   // Listen for training start event from TrainingConfig (ALWAYS active)

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -43,21 +43,27 @@ export default function TrainingMonitor() {
 
   const logPollerRef = useRef<LogPoller | null>(null);
   const drainTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const logContainerRef = useRef<HTMLDivElement>(null);
   const logsEndRef = useRef<HTMLDivElement>(null);
-  const MAX_LOGS = 1000;
+  const MAX_LOGS = 500;
 
   // Updated synchronously during render so effect cleanups always see the
   // latest value — useEffect deps are stale closures, refs are not.
   const isTrainingRef = useRef(status.is_training);
   isTrainingRef.current = status.is_training;
 
-  // Auto-scroll logs to bottom
-  const scrollToBottom = () => {
-    logsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  };
-
+  // Auto-scroll only when the user is already near the bottom, deferred via
+  // requestAnimationFrame so it runs outside React's commit phase and avoids
+  // forcing a synchronous layout recalc on every log update.
   useEffect(() => {
-    scrollToBottom();
+    const container = logContainerRef.current;
+    if (!container) return;
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    if (scrollHeight - scrollTop - clientHeight < 120) {
+      requestAnimationFrame(() => {
+        logsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      });
+    }
   }, [logs]);
 
   // Listen for training start event from TrainingConfig (ALWAYS active)
@@ -358,7 +364,7 @@ export default function TrainingMonitor() {
           </span>
         </div>
 
-        <div className="bg-background p-4 font-mono text-sm text-green-400 h-96 overflow-y-auto">
+        <div ref={logContainerRef} className="bg-background p-4 font-mono text-sm text-green-400 h-96 overflow-y-auto">
           {logs.length === 0 ? (
             <div className="text-muted-foreground text-center py-8">
               {status.is_training


### PR DESCRIPTION
## Summary

- **TrainingMonitor**: Replace unconditional `scrollIntoView` in `useEffect([logs])` with a smart near-bottom guard + `requestAnimationFrame` deferral, eliminating the forced layout recalc on every log update. Added `logContainerRef` to the scroll container. Lowered `MAX_LOGS` from 1000 → 500.
- **Auto-tag page**: Converted 4 raw `<button>` elements to shadcn `<Button>` (Start, Stop, log expand, log clear). Added `position="item-aligned"` to all 3 `SelectContent` components (dataset, model, extension) to remove Floating UI's `getBoundingClientRect` call on `SelectTrigger` mousedown.
- **BETA_PLANNING.md**: Expanded §11.1 with the ComfyUI planning decisions from today's session — submodule approach, B2 workflow state architecture, extension model, LoRA Manager button pattern, and ANIMA ↔ SDXL architecture switcher.

## Root causes fixed

| Violation | Root cause | Fix |
|-----------|-----------|-----|
| Forced reflow ~30-64ms on log update | `scrollIntoView` in `useEffect([logs])` fires on every incoming log | Near-bottom guard + `requestAnimationFrame` deferral |
| `mousedown` handler ~266ms on SelectTrigger | `position="popper"` triggers Floating UI `getBoundingClientRect` | `position="item-aligned"` (CSS-only, no layout reads) |
| Raw buttons violating shadcn rule | 4 `<button>` elements on auto-tag page | Converted to `<Button>` |

## Test plan

- [ ] Start a training run — log panel should auto-scroll smoothly without console reflow violations
- [ ] Scroll up in the log panel during training — auto-scroll should pause (not hijack position)
- [ ] Open the dataset / model / extension selects on the auto-tag page — no forced reflow in DevTools
- [ ] Start and stop tagging — Start/Stop buttons render and behave correctly

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded ComfyUI integration planning with an all-in-one shipping decision, detailed workflow state architecture, extension model for community templates, architecture switcher, node-presence validation, and follow-up notes.

* **Refactor**
  * Standardized UI controls in the Auto-Tagging/Capture flow to use a unified button component, consistent dropdown placement, accessible toggles, and improved Start/Stop behavior.

* **Bug Fixes**
  * Improved training log autoscroll to respect user position and reduced in-memory log buffering for better performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/pull/375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->