### PR TITLE
fix: resolve training log stream cutout after ~1000 lines

### DIFF
--- a/api/routes/training.py
+++ b/api/routes/training.py
@@ -401,7 +401,7 @@ async def get_training_logs(job_id: str, since: int = 0, limit: int = 0):
             "success": True,
             "job_id": job_id,
             "logs": formatted_logs,
-            "total_logs": len(job.logs),
+            "total_logs": job.total_lines_written,
             "status": job.status.value,
             "progress": job.progress,
             "step_num": job.step_num,
@@ -412,7 +412,7 @@ async def get_training_logs(job_id: str, since: int = 0, limit: int = 0):
             "lr": job.lr,
             "eta_seconds": job.eta_seconds,
             "error": job.error,
-            "next_since": since + len(logs),
+            "next_since": job.total_lines_written,
         }
 
     except HTTPException:

--- a/services/jobs/job.py
+++ b/services/jobs/job.py
@@ -42,8 +42,13 @@ class Job:
     total_images: Optional[int] = None
 
     # Log buffer (keep last max_logs lines)
-    logs: deque = field(default_factory=lambda: deque(maxlen=1000))
-    max_logs: int = 1000
+    logs: deque = field(default_factory=lambda: deque(maxlen=2000))
+    max_logs: int = 2000
+    # Absolute count of lines ever written — survives deque eviction.
+    # 'since' cursors from the frontend are absolute offsets into this counter,
+    # not relative indices into the deque. This prevents the deque wrap-around
+    # bug where get_logs(N) returns [] forever once N == maxlen.
+    total_lines_written: int = 0
 
     # Error tracking
     error: Optional[str] = None
@@ -52,20 +57,28 @@ class Job:
     def add_log(self, log_line: str):
         """Add log line to buffer"""
         self.logs.append(log_line)
+        self.total_lines_written += 1
 
-    def get_logs(self, start: int = 0) -> list[str]:
+    def get_logs(self, since: int = 0) -> list[str]:
         """
-        Get logs starting from line number.
+        Get logs since an absolute line number.
 
         Args:
-            start: Line number to start from (0-indexed)
+            since: Absolute line count offset (matches total_lines_written
+                   at the time the caller last received logs). NOT a deque index.
 
         Returns:
-            List of log lines from start onwards
+            List of log lines from since onwards (capped to buffered window).
         """
-        if start >= len(self.logs):
+        # Oldest absolute line number still in the deque
+        oldest_absolute = self.total_lines_written - len(self.logs)
+        if since <= oldest_absolute:
+            # Caller is behind the buffer window — return everything buffered
+            return list(self.logs)
+        relative_start = since - oldest_absolute
+        if relative_start >= len(self.logs):
             return []
-        return list(self.logs)[start:]
+        return list(self.logs)[relative_start:]
 
     @property
     def is_running(self) -> bool:

--- a/services/jobs/job_manager.py
+++ b/services/jobs/job_manager.py
@@ -277,7 +277,7 @@ class JobManager:
             yield log_line
 
         # Then stream new logs as they arrive
-        last_line = len(job.logs)
+        last_line = job.total_lines_written
         heartbeat_counter = 0
 
         while not job.is_complete:
@@ -294,7 +294,7 @@ class JobManager:
             for log_line in new_logs:
                 yield log_line
 
-            last_line = len(job.logs)
+            last_line = job.total_lines_written
 
         # Send final logs after completion
         final_logs = job.get_logs(last_line)

--- a/tests/test_job_log_cursor.py
+++ b/tests/test_job_log_cursor.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for Job.get_logs absolute cursor behaviour.
+
+Regression tests for the deque wrap-around bug where get_logs(N) returned []
+forever once N reached the deque maxlen — causing the log stream to silently
+cut out after ~1000 lines (~5-7 min on a 4090).
+"""
+import pytest
+from services.jobs.job import Job
+from services.models.job import JobType
+
+
+def make_job(n_lines: int, maxlen: int = 2000) -> Job:
+    """Create a job and write n_lines log entries into it."""
+    j = Job(job_id="test", job_type=JobType.TRAINING)
+    j.logs.maxlen  # confirm deque is initialised
+    # Override maxlen for testing small cases without 2000-entry loops
+    from collections import deque
+    j.logs = deque(maxlen=maxlen)
+    j.total_lines_written = 0
+    for i in range(n_lines):
+        j.add_log(f"line {i}")
+    return j
+
+
+class TestGetLogsBeforeEviction:
+    """Buffer not yet full — no eviction, simple indexing."""
+
+    def test_get_all_from_zero(self):
+        j = make_job(100, maxlen=200)
+        assert j.get_logs(0) == [f"line {i}" for i in range(100)]
+
+    def test_get_from_middle(self):
+        j = make_job(100, maxlen=200)
+        assert j.get_logs(50) == [f"line {i}" for i in range(50, 100)]
+
+    def test_get_at_tip_returns_empty(self):
+        j = make_job(100, maxlen=200)
+        assert j.get_logs(100) == []
+
+    def test_get_past_tip_returns_empty(self):
+        j = make_job(100, maxlen=200)
+        assert j.get_logs(200) == []
+
+    def test_total_lines_written_tracks_count(self):
+        j = make_job(100, maxlen=200)
+        assert j.total_lines_written == 100
+
+
+class TestGetLogsAfterEviction:
+    """Buffer full — oldest entries evicted; absolute cursor must still work."""
+
+    def test_cursor_at_zero_returns_all_buffered(self):
+        # 500 lines into a 200-entry buffer → first 300 evicted
+        j = make_job(500, maxlen=200)
+        result = j.get_logs(0)
+        assert len(result) == 200
+        assert result[0] == "line 300"   # oldest still buffered
+
+    def test_cursor_behind_oldest_returns_all_buffered(self):
+        j = make_job(500, maxlen=200)
+        # since=299 is still inside the evicted window → return all buffered
+        result = j.get_logs(299)
+        assert len(result) == 200
+        assert result[0] == "line 300"
+
+    def test_cursor_at_oldest_returns_all_buffered(self):
+        j = make_job(500, maxlen=200)
+        # since=300 is exactly at oldest_absolute → return all buffered
+        result = j.get_logs(300)
+        assert len(result) == 200
+
+    def test_cursor_inside_buffer(self):
+        j = make_job(500, maxlen=200)
+        # since=400 → oldest_absolute=300, relative=100, should return last 100
+        result = j.get_logs(400)
+        assert len(result) == 100
+        assert result[0] == "line 400"
+        assert result[-1] == "line 499"
+
+    def test_cursor_at_tip_returns_empty(self):
+        j = make_job(500, maxlen=200)
+        assert j.get_logs(500) == []
+
+    def test_cursor_past_tip_returns_empty(self):
+        j = make_job(500, maxlen=200)
+        assert j.get_logs(999) == []
+
+    def test_total_lines_written_past_maxlen(self):
+        j = make_job(500, maxlen=200)
+        assert j.total_lines_written == 500
+        assert len(j.logs) == 200
+
+    def test_regression_next_since_never_stalls(self):
+        """
+        Simulate the polling loop that caused the original cutout.
+        With the old code, next_since would reach maxlen and get stuck.
+        With the fix, next_since advances past maxlen via total_lines_written.
+        """
+        j = make_job(0, maxlen=10)
+        next_since = 0
+
+        for i in range(25):
+            j.add_log(f"line {i}")
+            new_logs = j.get_logs(next_since)
+            next_since = j.total_lines_written
+            # There should always be exactly 1 new log per iteration
+            assert len(new_logs) == 1, (
+                f"iteration {i}: expected 1 new log, got {len(new_logs)} "
+                f"(next_since was {next_since - 1}, total={j.total_lines_written})"
+            )
+
+        assert next_since == 25


### PR DESCRIPTION
## Summary

- **Root cause:** `Job.logs` is a `deque(maxlen=1000)`. The `get_logs(since)` method treated `since` as a buffer-relative index. Once the deque filled to 1000 entries, `get_logs(1000)` always hit `start >= len(logs)` → returned `[]` forever. The frontend received empty log responses silently (status still `running`), so no error appeared — logs just stopped.
- **Why 5–7 minutes:** At Kohya's tqdm logging rate on a 4090, 1000 lines accumulates in exactly that window.
- **Fix:** Added `total_lines_written` as an absolute counter on `Job`. `get_logs` now treats `since` as an absolute offset and correctly handles deque eviction — callers behind the eviction window get all buffered lines; callers at the tip get `[]`. Raised `deque(maxlen=1000)` → `deque(maxlen=2000)` for headroom.
- **Same fix applied to WebSocket streaming path** (`stream_logs` in `job_manager.py`) which had the same `last_line = len(job.logs)` stall bug.
- **Regression test:** 13 unit tests covering pre-eviction, post-eviction, and the exact polling loop regression.

## Files changed

| File | Change |
|------|--------|
| `services/jobs/job.py` | Add `total_lines_written` counter; rewrite `get_logs` with absolute cursor; deque maxlen 1000→2000 |
| `services/jobs/job_manager.py` | `stream_logs`: use `total_lines_written` instead of `len(job.logs)` |
| `api/routes/training.py` | `next_since` and `total_logs` use `total_lines_written` |
| `tests/test_job_log_cursor.py` | 13 regression tests, all green |

## Test plan

- [ ] Run `pytest tests/test_job_log_cursor.py -v` — 13 passed
- [ ] Start a training run longer than 7 minutes — log stream should continue past the 1000-line mark without interruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)