### PR TITLE
feat: dataset upload progress bar (#349)

### DIFF
--- a/frontend/components/DatasetUploader.tsx
+++ b/frontend/components/DatasetUploader.tsx
@@ -20,6 +20,8 @@ import { zipSync } from 'fflate';
 import { toast } from 'sonner';
 import { datasetAPI, API_BASE } from '@/lib/api';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
 
 interface UploadedFile {
   file: File;
@@ -42,7 +44,8 @@ export default function DatasetUploader() {
   const [files, setFiles] = useState<UploadedFile[]>([]);
   const filesRef = useRef<UploadedFile[]>([]);
   const [uploading, setUploading] = useState(false);
-  const uploadControllerRef = useRef<AbortController | null>(null);
+  const [zipUploadProgress, setZipUploadProgress] = useState(0);
+  const uploadControllerRef = useRef<{ abort: () => void } | null>(null);
 
   // URL/ZIP Download State
   const [projectName, setProjectName] = useState('');
@@ -210,7 +213,6 @@ export default function DatasetUploader() {
 
   // Zip and upload as single request (Remote GPU mode)
   const handleUploadZipped = async (imageFiles: UploadedFile[]) => {
-    // Mark all as uploading
     setFiles(prev =>
       prev.map(f =>
         imageFiles.some(img => img.file === f.file)
@@ -219,7 +221,6 @@ export default function DatasetUploader() {
       )
     );
 
-    // Build zip in memory
     const zipData: { [key: string]: [Uint8Array, { level: 6 }] } = {};
     for (const fileObj of imageFiles) {
       const buf = await fileObj.file.arrayBuffer();
@@ -229,41 +230,18 @@ export default function DatasetUploader() {
     const zipped = zipSync(zipData);
     const zipBlob = new Blob([zipped.buffer as ArrayBuffer], { type: 'application/zip' });
 
-    // Upload single zip
     const formData = new FormData();
     formData.append('file', new File([zipBlob], `${datasetName}.zip`, { type: 'application/zip' }));
     formData.append('dataset_name', datasetName);
 
-    const controller = new AbortController();
-    uploadControllerRef.current = controller;
-    const timeoutId = setTimeout(() => controller.abort(), 600000);
-
-    const response = await fetch(`${API_BASE}/dataset/upload-zip`, {
-      method: 'POST',
-      body: formData,
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      const contentType = response.headers.get('content-type');
-      if (contentType && contentType.includes('application/json')) {
-        const error = await response.json();
-        throw new Error(error.detail || 'Upload failed');
-      } else {
-        const text = await response.text();
-        throw new Error(`Server error (${response.status}): ${text.substring(0, 200)}`);
-      }
-    }
-
-    const result = await response.json();
+    setZipUploadProgress(0);
+    const result = await xhrUpload(`${API_BASE}/dataset/upload-zip`, formData, setZipUploadProgress) as { success: boolean; extracted?: number };
+    setZipUploadProgress(0);
 
     if (!result.success) {
       throw new Error(`No files extracted from ZIP (got ${result.extracted || 0} files)`);
     }
 
-    // Mark all as success
     setFiles(prev =>
       prev.map(f =>
         imageFiles.some(img => img.file === f.file)
@@ -287,68 +265,36 @@ export default function DatasetUploader() {
       return;
     }
 
-    // Check if dataset exists and confirm
     if (datasetExists) {
       if (!confirm(`Dataset "${datasetName}" already exists!\n\nZIP contents will be extracted to the existing dataset. Continue?`)) {
         return;
       }
     }
 
-    // Validate the file exists and has size
     const zipFile = zipFiles[0].file;
     if (!zipFile || zipFile.size === 0) {
       toast.error('ZIP file is empty or not loaded yet');
       return;
     }
 
-    console.log(`📦 Uploading ZIP: ${zipFile.name} (${(zipFile.size / 1024 / 1024).toFixed(2)} MB)`);
     setUploading(true);
+    setZipUploadProgress(0);
 
     try {
       const formData = new FormData();
       formData.append('file', zipFile);
       formData.append('dataset_name', datasetName);
 
-      console.log('🚀 Sending ZIP to backend...');
-
-      // Add timeout to prevent hanging forever (10 mins for slow networks)
-      const controller = new AbortController();
-      uploadControllerRef.current = controller;
-      const timeoutId = setTimeout(() => controller.abort(), 600000); // 10 minute timeout
-
-      const response = await fetch(`${API_BASE}/dataset/upload-zip`, {
-        method: 'POST',
-        body: formData,
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-      console.log(`📥 Response status: ${response.status}`);
-
-      if (!response.ok) {
-        // Check if response is JSON before parsing
-        const contentType = response.headers.get('content-type');
-        if (contentType && contentType.includes('application/json')) {
-          const error = await response.json();
-          throw new Error(error.detail || 'Upload failed');
-        } else {
-          const text = await response.text();
-          throw new Error(`Server error (${response.status}): ${text.substring(0, 200)}`);
-        }
-      }
-
-      const result = await response.json();
-      console.log('📊 Result:', result);
+      const result = await xhrUpload(`${API_BASE}/dataset/upload-zip`, formData, setZipUploadProgress) as { success: boolean; extracted?: number; errors?: string[] };
+      setZipUploadProgress(0);
 
       if (result.success) {
-        console.log(`✅ Extracted ${result.extracted} images`);
         toast.success(`ZIP uploaded! Extracted ${result.extracted} images`, {
-          description: result.errors.length > 0 ? `Errors: ${result.errors.join(', ')}` : undefined,
+          description: result.errors && result.errors.length > 0 ? `Errors: ${result.errors.join(', ')}` : undefined,
         });
         revokePreviewUrls(files);
         setFiles([]);
 
-        // Reload existing datasets list
         try {
           const data = await datasetAPI.list();
           setExistingDatasets((data.datasets || []).map(d => d.name));
@@ -356,15 +302,14 @@ export default function DatasetUploader() {
           console.error('Failed to reload datasets:', err);
         }
       } else {
-        console.error('❌ No files extracted');
         throw new Error(`No files extracted from ZIP (got ${result.extracted || 0} files)`);
       }
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') return;
-      console.error('❌ Upload error:', err);
       toast.error(`ZIP upload failed: ${err}`);
     } finally {
       setUploading(false);
+      setZipUploadProgress(0);
     }
   };
 
@@ -398,6 +343,32 @@ export default function DatasetUploader() {
     setFiles([]);
     setUploading(false);
   };
+
+  // XHR-based upload with progress tracking
+  const xhrUpload = (url: string, formData: FormData, onProgress: (pct: number) => void): Promise<unknown> =>
+    new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', url);
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100));
+      };
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          try { resolve(JSON.parse(xhr.responseText)); } catch { reject(new Error('Invalid JSON response')); }
+        } else {
+          try {
+            const err = JSON.parse(xhr.responseText) as { detail?: string };
+            reject(new Error(err.detail || `Server error (${xhr.status})`));
+          } catch {
+            reject(new Error(`Server error (${xhr.status}): ${xhr.responseText.substring(0, 200)}`));
+          }
+        }
+      };
+      xhr.onerror = () => reject(new Error('Network error'));
+      xhr.onabort = () => { const e = new Error('Upload cancelled'); e.name = 'AbortError'; reject(e); };
+      uploadControllerRef.current = { abort: () => xhr.abort() };
+      xhr.send(formData);
+    });
 
   // ========== URL/ZIP Download Handlers ==========
 
@@ -620,22 +591,28 @@ export default function DatasetUploader() {
                   {zipCount > 0 && ` · ${zipCount} ZIP`}
                 </h3>
                 <div className="flex gap-2">
-                  <button
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={handleReset}
-                    className="text-sm text-yellow-600 dark:text-yellow-400 hover:text-yellow-700 dark:hover:text-yellow-300 flex items-center gap-1 font-semibold"
                     title="Force reset - always works even if upload is stuck"
+                    className="text-yellow-600 dark:text-yellow-400 hover:text-yellow-700 dark:hover:text-yellow-300 gap-1 h-auto py-0 px-1"
                   >
                     <RefreshCw className="w-3 h-3" />
                     Reset {uploading && '(Force)'}
-                  </button>
-                  <button
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={handleClear}
-                    className="text-sm text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 flex items-center gap-1"
                     disabled={uploading}
+                    className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 gap-1 h-auto py-0 px-1"
                   >
                     <X className="w-3 h-3" />
                     Clear All
-                  </button>
+                  </Button>
                 </div>
               </div>
 
@@ -722,27 +699,40 @@ export default function DatasetUploader() {
           {/* Action Buttons */}
           <div className="flex gap-3">
             {zipCount > 0 && (
-              <button
+              <Button
+                type="button"
                 onClick={handleUploadZip}
                 disabled={uploading || zipCount === 0}
-                className="flex-1 flex items-center justify-center gap-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-purple-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                className="flex-1 gap-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white hover:from-purple-600 hover:to-purple-700"
               >
                 <FileArchive className="w-5 h-5" />
                 {uploading ? 'Extracting...' : `Extract ${zipCount} ZIP`}
-              </button>
+              </Button>
             )}
 
             {imageCount > 0 && (
-              <button
+              <Button
+                type="button"
                 onClick={handleUpload}
                 disabled={uploading || imageCount === 0}
-                className="flex-1 flex items-center justify-center gap-2 bg-gradient-to-r from-blue-500 to-indigo-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-blue-600 hover:to-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                className="flex-1 gap-2 bg-gradient-to-r from-blue-500 to-indigo-600 text-white hover:from-blue-600 hover:to-indigo-700"
               >
                 <Upload className="w-5 h-5" />
                 {uploading ? 'Uploading...' : `Upload ${imageCount} Images`}
-              </button>
+              </Button>
             )}
           </div>
+
+          {/* Upload Progress */}
+          {uploading && zipUploadProgress > 0 && (
+            <div className="space-y-1">
+              <div className="flex justify-between text-xs text-muted-foreground">
+                <span>Uploading...</span>
+                <span>{zipUploadProgress}%</span>
+              </div>
+              <Progress value={zipUploadProgress} className="h-2" />
+            </div>
+          )}
 
           {/* Success Message */}
           {successCount === files.length && files.length > 0 && (
@@ -810,14 +800,15 @@ export default function DatasetUploader() {
           </div>
 
           {/* Download Button */}
-          <button
+          <Button
+            type="button"
             onClick={handleUrlDownload}
             disabled={downloading || !projectName.trim() || !datasetUrl.trim()}
-            className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-purple-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            className="w-full gap-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white hover:from-purple-600 hover:to-purple-700"
           >
             <Download className="w-5 h-5" />
             {downloading ? 'Downloading & Extracting...' : 'Download & Extract Dataset'}
-          </button>
+          </Button>
         </TabsContent>
 
         {/* ========== Create Folder Tab ========== */}
@@ -883,14 +874,15 @@ export default function DatasetUploader() {
           )}
 
           {/* Create Button */}
-          <button
+          <Button
+            type="button"
             onClick={handleCreateFolder}
             disabled={creatingFolder || !folderName.trim()}
-            className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-green-500 to-green-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-green-600 hover:to-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            className="w-full gap-2 bg-gradient-to-r from-green-500 to-green-600 text-white hover:from-green-600 hover:to-green-700"
           >
             <FolderPlus className="w-5 h-5" />
             {creatingFolder ? 'Creating...' : 'Create Folder'}
-          </button>
+          </Button>
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/components/DatasetUploader.tsx
+++ b/frontend/components/DatasetUploader.tsx
@@ -349,6 +349,7 @@ export default function DatasetUploader() {
     new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
       xhr.open('POST', url);
+      xhr.timeout = 600000; // 10 minutes for large uploads
       xhr.upload.onprogress = (e) => {
         if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100));
       };
@@ -365,6 +366,7 @@ export default function DatasetUploader() {
         }
       };
       xhr.onerror = () => reject(new Error('Network error'));
+      xhr.ontimeout = () => reject(new Error('Upload timed out after 10 minutes'));
       xhr.onabort = () => { const e = new Error('Upload cancelled'); e.name = 'AbortError'; reject(e); };
       uploadControllerRef.current = { abort: () => xhr.abort() };
       xhr.send(formData);


### PR DESCRIPTION
## Summary

- Converts handleUploadZipped and handleUploadZip from fetch() to XMLHttpRequest so xhr.upload.onprogress can track bytes sent
- Adds a shared xhrUpload helper used by both paths; abort wired through existing uploadControllerRef
- Shows a shadcn Progress bar with percentage label during ZIP/zipped uploads
- Converts all raw button elements to shadcn Button per project conventions

Closes #349

## Test plan

- [ ] Drop images in Remote GPU mode -> Uploading... button appears, progress bar fills 0->100%, success toast fires
- [ ] Drop a ZIP file -> Extracting... button, progress bar fills, success toast with extracted count
- [ ] Cancel mid-upload (navigate away) -> upload aborts cleanly, no hanging state
- [ ] Batch image upload (local mode) -- still works, no progress bar shown (fetch path unchanged)
- [ ] All buttons in Direct Upload, URL/ZIP, and Create Folder tabs render correctly with theme

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload progress tracking displays real-time status for file uploads
  * Ability to cancel uploads in progress
  * Confirmation dialog when dataset already exists

* **Improvements**
  * Enhanced validation for uploaded ZIP files
  * Improved error messaging and notifications
  * Standardized button components throughout the interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->