### PR TITLE
feat: chunked ZIP uploads with retry and progress (#349)

### DIFF
--- a/frontend/app/api/dataset/upload-chunk-finalize/route.ts
+++ b/frontend/app/api/dataset/upload-chunk-finalize/route.ts
@@ -1,0 +1,103 @@
+/**
+ * Next.js API Route: POST /api/dataset/upload-chunk-finalize
+ * Assembles all uploaded chunks and extracts the ZIP into a dataset.
+ *
+ * Reads the session's part_XXXX files in index order, concatenates them
+ * into a single Buffer, then proxies that buffer to the FastAPI
+ * /api/dataset/upload-zip endpoint which handles the ZIP extraction.
+ * Temp chunks are always cleaned up, even on failure.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+/** Resolve the FastAPI backend base URL — mirrors the pattern used in upload-zip/route.ts. */
+function backendBase(): string {
+  const dev = process.env.NODE_ENV !== 'production';
+  const defaultPort = dev ? '8000' : (process.env.BACKEND_PORT || '18000');
+  return process.env.BACKEND_URL || `http://127.0.0.1:${defaultPort}`;
+}
+
+interface SessionMeta {
+  totalChunks: number;
+  fileName: string;
+}
+
+/**
+ * Assemble all chunks for an upload session and extract the resulting ZIP.
+ *
+ * Expects JSON body `{ uploadId, fileName, datasetName }`.
+ * Concatenates `part_0000` … `part_NNNN` in order, posts the assembled
+ * buffer to the FastAPI upload-zip endpoint, then deletes the scratch dir.
+ *
+ * @returns The FastAPI extraction response on success.
+ */
+export async function POST(request: NextRequest) {
+  let chunkDir: string | null = null;
+
+  try {
+    const body = await request.json() as { uploadId?: unknown; fileName?: unknown; datasetName?: unknown };
+    const { uploadId, fileName, datasetName } = body;
+
+    if (typeof uploadId !== 'string' || typeof fileName !== 'string' || typeof datasetName !== 'string') {
+      return NextResponse.json(
+        { error: 'uploadId, fileName, and datasetName are required strings' },
+        { status: 400 },
+      );
+    }
+
+    const safeId = uploadId.replace(/[^a-zA-Z0-9-]/g, '');
+    chunkDir = path.join(os.tmpdir(), 'ktiseos_uploads', safeId);
+
+    const metaRaw = await fs.readFile(path.join(chunkDir, 'meta.json'), 'utf-8');
+    const meta = JSON.parse(metaRaw) as SessionMeta;
+
+    // Assemble chunks in order
+    const buffers: Buffer[] = [];
+    for (let i = 0; i < meta.totalChunks; i++) {
+      const chunkPath = path.join(chunkDir, `part_${String(i).padStart(4, '0')}`);
+      buffers.push(await fs.readFile(chunkPath));
+    }
+    const assembled = Buffer.concat(buffers);
+
+    // Proxy assembled file to FastAPI for ZIP extraction
+    const formData = new FormData();
+    formData.append('file', new Blob([assembled], { type: 'application/zip' }), fileName);
+    formData.append('dataset_name', datasetName);
+
+    const res = await fetch(`${backendBase()}/api/dataset/upload-zip`, {
+      method: 'POST',
+      body: formData,
+    });
+
+    const contentType = res.headers.get('content-type') || '';
+
+    if (!res.ok) {
+      const errText = await res.text();
+      return NextResponse.json(
+        { error: `Backend ${res.status}`, detail: errText.slice(0, 1000) },
+        { status: res.status },
+      );
+    }
+
+    if (contentType.includes('application/json')) {
+      return NextResponse.json(await res.json(), { status: res.status });
+    }
+
+    const text = await res.text();
+    try {
+      return NextResponse.json(JSON.parse(text), { status: res.status });
+    } catch {
+      return NextResponse.json({ success: true, detail: text.slice(0, 1000) }, { status: res.status });
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: 'Finalize failed', detail: msg }, { status: 500 });
+  } finally {
+    // Always clean up — even if FastAPI returned an error
+    if (chunkDir) {
+      fs.rm(chunkDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+}

--- a/frontend/app/api/dataset/upload-chunk-finalize/route.ts
+++ b/frontend/app/api/dataset/upload-chunk-finalize/route.ts
@@ -9,6 +9,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
+import { createWriteStream } from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -53,13 +54,37 @@ export async function POST(request: NextRequest) {
     const metaRaw = await fs.readFile(path.join(chunkDir, 'meta.json'), 'utf-8');
     const meta = JSON.parse(metaRaw) as SessionMeta;
 
-    // Assemble chunks in order
-    const buffers: Buffer[] = [];
+    // Validate all chunks are present before attempting assembly
     for (let i = 0; i < meta.totalChunks; i++) {
       const chunkPath = path.join(chunkDir, `part_${String(i).padStart(4, '0')}`);
-      buffers.push(await fs.readFile(chunkPath));
+      try {
+        await fs.access(chunkPath);
+      } catch {
+        return NextResponse.json(
+          { error: `Missing chunk ${i} of ${meta.totalChunks} — upload may be incomplete` },
+          { status: 400 },
+        );
+      }
     }
-    const assembled = Buffer.concat(buffers);
+
+    // Stream chunks into a single temp file (avoids loading all chunks into RAM simultaneously)
+    const assembledPath = path.join(chunkDir, 'assembled.zip');
+    await new Promise<void>((resolve, reject) => {
+      const ws = createWriteStream(assembledPath);
+      ws.on('error', reject);
+      ws.on('finish', resolve);
+      (async () => {
+        for (let i = 0; i < meta.totalChunks; i++) {
+          const chunkPath = path.join(chunkDir, `part_${String(i).padStart(4, '0')}`);
+          const data = await fs.readFile(chunkPath);
+          if (!ws.write(data)) await new Promise<void>(r => ws.once('drain', r));
+        }
+        ws.end();
+      })().catch(reject);
+    });
+
+    // Read assembled file once for the FormData body
+    const assembled = await fs.readFile(assembledPath);
 
     // Proxy assembled file to FastAPI for ZIP extraction
     const formData = new FormData();

--- a/frontend/app/api/dataset/upload-chunk-init/route.ts
+++ b/frontend/app/api/dataset/upload-chunk-init/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Next.js API Route: POST /api/dataset/upload-chunk-init
+ * Opens a chunked-upload session for a single ZIP file.
+ *
+ * The client calls this once before sending chunks, receiving an upload_id
+ * it passes to every subsequent /upload-chunk and /upload-chunk-finalize call.
+ * Chunks are stored under os.tmpdir()/ktiseos_uploads/<uploadId>/.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Initialise a chunked-upload session.
+ *
+ * Expects JSON body `{ uploadId, fileName, totalChunks }`.
+ * Creates a scratch directory in the OS temp folder and writes session
+ * metadata so the finalize route knows how many parts to assemble.
+ *
+ * @returns `{ status: 'ready', uploadId }` on success.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as { uploadId?: unknown; fileName?: unknown; totalChunks?: unknown };
+    const { uploadId, fileName, totalChunks } = body;
+
+    if (typeof uploadId !== 'string' || typeof fileName !== 'string' || typeof totalChunks !== 'number') {
+      return NextResponse.json({ error: 'uploadId (string), fileName (string), and totalChunks (number) are required' }, { status: 400 });
+    }
+
+    // UUID-only characters — prevents path traversal
+    const safeId = uploadId.replace(/[^a-zA-Z0-9-]/g, '');
+    if (!safeId) {
+      return NextResponse.json({ error: 'Invalid uploadId' }, { status: 400 });
+    }
+
+    const chunkDir = path.join(os.tmpdir(), 'ktiseos_uploads', safeId);
+    await fs.mkdir(chunkDir, { recursive: true });
+    await fs.writeFile(
+      path.join(chunkDir, 'meta.json'),
+      JSON.stringify({ uploadId: safeId, fileName, totalChunks, createdAt: Date.now() }),
+    );
+
+    return NextResponse.json({ status: 'ready', uploadId: safeId });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/frontend/app/api/dataset/upload-chunk/route.ts
+++ b/frontend/app/api/dataset/upload-chunk/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Next.js API Route: POST /api/dataset/upload-chunk
+ * Receives one chunk of a chunked ZIP upload and writes it to disk.
+ *
+ * Expects multipart/form-data with:
+ *   chunk   – binary file slice
+ *   uploadId – session ID from /upload-chunk-init
+ *   index   – zero-based chunk index (used for ordered assembly)
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Write one chunk to the upload session's scratch directory.
+ *
+ * Chunks are stored as `part_XXXX` (zero-padded index) so the finalize
+ * route can reassemble them in order without metadata lookups.
+ *
+ * @returns `{ status: 'chunk_saved', index }` on success.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const chunk = formData.get('chunk');
+    const uploadId = formData.get('uploadId');
+    const rawIndex = formData.get('index');
+
+    if (!(chunk instanceof File) || typeof uploadId !== 'string' || typeof rawIndex !== 'string') {
+      return NextResponse.json({ error: 'chunk (file), uploadId, and index are required' }, { status: 400 });
+    }
+
+    const index = parseInt(rawIndex, 10);
+    if (isNaN(index) || index < 0) {
+      return NextResponse.json({ error: 'index must be a non-negative integer' }, { status: 400 });
+    }
+
+    const safeId = uploadId.replace(/[^a-zA-Z0-9-]/g, '');
+    const chunkDir = path.join(os.tmpdir(), 'ktiseos_uploads', safeId);
+
+    // Reject chunks for sessions that were never initialised
+    try {
+      await fs.access(chunkDir);
+    } catch {
+      return NextResponse.json(
+        { error: 'Upload session not found — call /upload-chunk-init first' },
+        { status: 404 },
+      );
+    }
+
+    const chunkPath = path.join(chunkDir, `part_${String(index).padStart(4, '0')}`);
+    await fs.writeFile(chunkPath, Buffer.from(await chunk.arrayBuffer()));
+
+    return NextResponse.json({ status: 'chunk_saved', index });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/frontend/app/api/dataset/upload-chunk/route.ts
+++ b/frontend/app/api/dataset/upload-chunk/route.ts
@@ -12,6 +12,8 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
+const MAX_CHUNK_SIZE = 12 * 1024 * 1024; // 12 MB — slightly above the 10 MB client default
+
 /**
  * Write one chunk to the upload session's scratch directory.
  *
@@ -29,6 +31,13 @@ export async function POST(request: NextRequest) {
 
     if (!(chunk instanceof File) || typeof uploadId !== 'string' || typeof rawIndex !== 'string') {
       return NextResponse.json({ error: 'chunk (file), uploadId, and index are required' }, { status: 400 });
+    }
+
+    if (chunk.size > MAX_CHUNK_SIZE) {
+      return NextResponse.json(
+        { error: `Chunk exceeds maximum size of ${MAX_CHUNK_SIZE} bytes` },
+        { status: 413 },
+      );
     }
 
     const index = parseInt(rawIndex, 10);

--- a/frontend/app/api/dataset/upload-chunk/route.ts
+++ b/frontend/app/api/dataset/upload-chunk/route.ts
@@ -33,6 +33,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'chunk (file), uploadId, and index are required' }, { status: 400 });
     }
 
+    if (chunk.size === 0) {
+      return NextResponse.json({ error: 'Chunk is empty' }, { status: 400 });
+    }
+
     if (chunk.size > MAX_CHUNK_SIZE) {
       return NextResponse.json(
         { error: `Chunk exceeds maximum size of ${MAX_CHUNK_SIZE} bytes` },

--- a/frontend/components/DatasetUploader.tsx
+++ b/frontend/components/DatasetUploader.tsx
@@ -264,19 +264,22 @@ export default function DatasetUploader() {
       }
     }
 
-    const finalRes = await fetch('/api/dataset/upload-chunk-finalize', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ uploadId, fileName, datasetName: targetDatasetName }),
-    });
-    setZipUploadProgress(0);
+    try {
+      const finalRes = await fetch('/api/dataset/upload-chunk-finalize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uploadId, fileName, datasetName: targetDatasetName }),
+      });
 
-    if (!finalRes.ok) {
-      const errData = await finalRes.json().catch(() => ({})) as { detail?: string; error?: string };
-      throw new Error(errData.detail || errData.error || 'Upload finalisation failed');
+      if (!finalRes.ok) {
+        const errData = await finalRes.json().catch(() => ({})) as { detail?: string; error?: string };
+        throw new Error(errData.detail || errData.error || 'Upload finalisation failed');
+      }
+
+      return finalRes.json() as Promise<{ success: boolean; extracted?: number; errors?: string[] }>;
+    } finally {
+      setZipUploadProgress(0);
     }
-
-    return finalRes.json() as Promise<{ success: boolean; extracted?: number; errors?: string[] }>;
   };
 
   // Remote GPU mode: zip images in memory, then send via chunked upload

--- a/frontend/components/DatasetUploader.tsx
+++ b/frontend/components/DatasetUploader.tsx
@@ -18,8 +18,10 @@ import {
 } from 'lucide-react';
 import { zipSync } from 'fflate';
 import { toast } from 'sonner';
-import { datasetAPI, API_BASE } from '@/lib/api';
+import { datasetAPI } from '@/lib/api';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
 
 interface UploadedFile {
   file: File;
@@ -42,7 +44,7 @@ export default function DatasetUploader() {
   const [files, setFiles] = useState<UploadedFile[]>([]);
   const filesRef = useRef<UploadedFile[]>([]);
   const [uploading, setUploading] = useState(false);
-  const uploadControllerRef = useRef<AbortController | null>(null);
+  const [zipUploadProgress, setZipUploadProgress] = useState(0);
 
   // URL/ZIP Download State
   const [projectName, setProjectName] = useState('');
@@ -208,147 +210,126 @@ export default function DatasetUploader() {
     }
   };
 
-  // Zip and upload as single request (Remote GPU mode)
+  // ========== Chunked ZIP Upload ==========
+
+  const CHUNK_SIZE = 10 * 1024 * 1024; // 10 MB per chunk
+  const MAX_RETRIES = 3;
+
+  /**
+   * Upload a ZIP file (File or in-memory Blob) in 10 MB chunks via the
+   * upload-chunk-init → upload-chunk × N → upload-chunk-finalize route trio.
+   * Progress is reported as chunk index / totalChunks.
+   * Each chunk is retried up to MAX_RETRIES times with exponential backoff.
+   */
+  const handleChunkedZipUpload = async (
+    zipFile: File | Blob,
+    fileName: string,
+    targetDatasetName: string,
+  ): Promise<{ success: boolean; extracted?: number; errors?: string[] }> => {
+    const uploadId = crypto.randomUUID();
+    const totalChunks = Math.ceil(zipFile.size / CHUNK_SIZE);
+
+    const initRes = await fetch('/api/dataset/upload-chunk-init', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ uploadId, fileName, totalChunks }),
+    });
+    if (!initRes.ok) throw new Error('Failed to initialise chunked upload');
+
+    setZipUploadProgress(0);
+
+    for (let i = 0; i < totalChunks; i++) {
+      let retries = 0;
+      while (retries < MAX_RETRIES) {
+        try {
+          const start = i * CHUNK_SIZE;
+          const chunk = zipFile.slice(start, start + CHUNK_SIZE);
+          const form = new FormData();
+          form.append('chunk', chunk, `part_${i}`);
+          form.append('uploadId', uploadId);
+          form.append('index', String(i));
+          const res = await fetch('/api/dataset/upload-chunk', {
+            method: 'POST',
+            body: form,
+            keepalive: true, // keeps Cloudflared/Caddy tunnel alive during slow chunks
+          });
+          if (!res.ok) throw new Error(`Chunk ${i} rejected by server`);
+          setZipUploadProgress(Math.round(((i + 1) / totalChunks) * 100));
+          break;
+        } catch (err) {
+          retries++;
+          if (retries === MAX_RETRIES) throw new Error(`Chunk ${i} failed after ${MAX_RETRIES} retries: ${err}`);
+          await new Promise(r => setTimeout(r, 1500 * retries));
+        }
+      }
+    }
+
+    const finalRes = await fetch('/api/dataset/upload-chunk-finalize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ uploadId, fileName, datasetName: targetDatasetName }),
+    });
+    setZipUploadProgress(0);
+
+    if (!finalRes.ok) {
+      const errData = await finalRes.json().catch(() => ({})) as { detail?: string; error?: string };
+      throw new Error(errData.detail || errData.error || 'Upload finalisation failed');
+    }
+
+    return finalRes.json() as Promise<{ success: boolean; extracted?: number; errors?: string[] }>;
+  };
+
+  // Remote GPU mode: zip images in memory, then send via chunked upload
   const handleUploadZipped = async (imageFiles: UploadedFile[]) => {
-    // Mark all as uploading
     setFiles(prev =>
       prev.map(f =>
-        imageFiles.some(img => img.file === f.file)
-          ? { ...f, status: 'uploading' }
-          : f
+        imageFiles.some(img => img.file === f.file) ? { ...f, status: 'uploading' } : f
       )
     );
 
-    // Build zip in memory
     const zipData: { [key: string]: [Uint8Array, { level: 6 }] } = {};
     for (const fileObj of imageFiles) {
       const buf = await fileObj.file.arrayBuffer();
       zipData[fileObj.file.name] = [new Uint8Array(buf), { level: 6 as const }];
     }
-
     const zipped = zipSync(zipData);
     const zipBlob = new Blob([zipped.buffer as ArrayBuffer], { type: 'application/zip' });
 
-    // Upload single zip
-    const formData = new FormData();
-    formData.append('file', new File([zipBlob], `${datasetName}.zip`, { type: 'application/zip' }));
-    formData.append('dataset_name', datasetName);
-
-    const controller = new AbortController();
-    uploadControllerRef.current = controller;
-    const timeoutId = setTimeout(() => controller.abort(), 600000);
-
-    const response = await fetch(`${API_BASE}/dataset/upload-zip`, {
-      method: 'POST',
-      body: formData,
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      const contentType = response.headers.get('content-type');
-      if (contentType && contentType.includes('application/json')) {
-        const error = await response.json();
-        throw new Error(error.detail || 'Upload failed');
-      } else {
-        const text = await response.text();
-        throw new Error(`Server error (${response.status}): ${text.substring(0, 200)}`);
-      }
-    }
-
-    const result = await response.json();
-
+    const result = await handleChunkedZipUpload(zipBlob, `${datasetName}.zip`, datasetName);
     if (!result.success) {
       throw new Error(`No files extracted from ZIP (got ${result.extracted || 0} files)`);
     }
 
-    // Mark all as success
     setFiles(prev =>
       prev.map(f =>
-        imageFiles.some(img => img.file === f.file)
-          ? { ...f, status: 'success', progress: 100 }
-          : f
+        imageFiles.some(img => img.file === f.file) ? { ...f, status: 'success', progress: 100 } : f
       )
     );
   };
 
-  // Upload and extract ZIP
+  // Direct ZIP drop: send via chunked upload
   const handleUploadZip = async () => {
     const zipFiles = files.filter(f => f.file.name.endsWith('.zip'));
 
-    if (zipFiles.length === 0) {
-      toast.warning('No ZIP files selected');
-      return;
-    }
+    if (zipFiles.length === 0) { toast.warning('No ZIP files selected'); return; }
+    if (!datasetName.trim()) { toast.warning('Please enter a dataset name'); return; }
 
-    if (!datasetName.trim()) {
-      toast.warning('Please enter a dataset name');
-      return;
-    }
-
-    // Check if dataset exists and confirm
     if (datasetExists) {
-      if (!confirm(`Dataset "${datasetName}" already exists!\n\nZIP contents will be extracted to the existing dataset. Continue?`)) {
-        return;
-      }
+      if (!confirm(`Dataset "${datasetName}" already exists!\n\nZIP contents will be extracted to the existing dataset. Continue?`)) return;
     }
 
-    // Validate the file exists and has size
     const zipFile = zipFiles[0].file;
-    if (!zipFile || zipFile.size === 0) {
-      toast.error('ZIP file is empty or not loaded yet');
-      return;
-    }
+    if (!zipFile || zipFile.size === 0) { toast.error('ZIP file is empty or not loaded yet'); return; }
 
-    console.log(`📦 Uploading ZIP: ${zipFile.name} (${(zipFile.size / 1024 / 1024).toFixed(2)} MB)`);
     setUploading(true);
-
     try {
-      const formData = new FormData();
-      formData.append('file', zipFile);
-      formData.append('dataset_name', datasetName);
-
-      console.log('🚀 Sending ZIP to backend...');
-
-      // Add timeout to prevent hanging forever (10 mins for slow networks)
-      const controller = new AbortController();
-      uploadControllerRef.current = controller;
-      const timeoutId = setTimeout(() => controller.abort(), 600000); // 10 minute timeout
-
-      const response = await fetch(`${API_BASE}/dataset/upload-zip`, {
-        method: 'POST',
-        body: formData,
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-      console.log(`📥 Response status: ${response.status}`);
-
-      if (!response.ok) {
-        // Check if response is JSON before parsing
-        const contentType = response.headers.get('content-type');
-        if (contentType && contentType.includes('application/json')) {
-          const error = await response.json();
-          throw new Error(error.detail || 'Upload failed');
-        } else {
-          const text = await response.text();
-          throw new Error(`Server error (${response.status}): ${text.substring(0, 200)}`);
-        }
-      }
-
-      const result = await response.json();
-      console.log('📊 Result:', result);
-
+      const result = await handleChunkedZipUpload(zipFile, zipFile.name, datasetName);
       if (result.success) {
-        console.log(`✅ Extracted ${result.extracted} images`);
         toast.success(`ZIP uploaded! Extracted ${result.extracted} images`, {
-          description: result.errors.length > 0 ? `Errors: ${result.errors.join(', ')}` : undefined,
+          description: result.errors && result.errors.length > 0 ? `Errors: ${result.errors.join(', ')}` : undefined,
         });
         revokePreviewUrls(files);
         setFiles([]);
-
-        // Reload existing datasets list
         try {
           const data = await datasetAPI.list();
           setExistingDatasets((data.datasets || []).map(d => d.name));
@@ -356,15 +337,13 @@ export default function DatasetUploader() {
           console.error('Failed to reload datasets:', err);
         }
       } else {
-        console.error('❌ No files extracted');
         throw new Error(`No files extracted from ZIP (got ${result.extracted || 0} files)`);
       }
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') return;
-      console.error('❌ Upload error:', err);
       toast.error(`ZIP upload failed: ${err}`);
     } finally {
       setUploading(false);
+      setZipUploadProgress(0);
     }
   };
 
@@ -375,14 +354,9 @@ export default function DatasetUploader() {
     });
   }, []);
 
-  // Abort any in-flight upload and revoke blob URLs on unmount.
-  // filesRef.current always holds the latest files list, so blob URLs created
-  // after mount are still revoked even though this effect has an empty dep array.
+  // Revoke blob URLs on unmount — filesRef.current always holds the latest list
   useEffect(() => {
-    return () => {
-      uploadControllerRef.current?.abort();
-      revokePreviewUrls(filesRef.current);
-    };
+    return () => { revokePreviewUrls(filesRef.current); };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -422,7 +396,7 @@ export default function DatasetUploader() {
     setDownloading(true);
 
     try {
-      const response = await fetch(`${API_BASE}/dataset/download-url`, {
+      const response = await fetch('/api/dataset/download-url', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -620,22 +594,28 @@ export default function DatasetUploader() {
                   {zipCount > 0 && ` · ${zipCount} ZIP`}
                 </h3>
                 <div className="flex gap-2">
-                  <button
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={handleReset}
-                    className="text-sm text-yellow-600 dark:text-yellow-400 hover:text-yellow-700 dark:hover:text-yellow-300 flex items-center gap-1 font-semibold"
                     title="Force reset - always works even if upload is stuck"
+                    className="text-yellow-600 dark:text-yellow-400 hover:text-yellow-700 dark:hover:text-yellow-300 gap-1 h-auto py-0 px-1"
                   >
                     <RefreshCw className="w-3 h-3" />
                     Reset {uploading && '(Force)'}
-                  </button>
-                  <button
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={handleClear}
-                    className="text-sm text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 flex items-center gap-1"
                     disabled={uploading}
+                    className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 gap-1 h-auto py-0 px-1"
                   >
                     <X className="w-3 h-3" />
                     Clear All
-                  </button>
+                  </Button>
                 </div>
               </div>
 
@@ -722,27 +702,40 @@ export default function DatasetUploader() {
           {/* Action Buttons */}
           <div className="flex gap-3">
             {zipCount > 0 && (
-              <button
+              <Button
+                type="button"
                 onClick={handleUploadZip}
                 disabled={uploading || zipCount === 0}
-                className="flex-1 flex items-center justify-center gap-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-purple-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                className="flex-1 gap-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white hover:from-purple-600 hover:to-purple-700"
               >
                 <FileArchive className="w-5 h-5" />
-                {uploading ? 'Extracting...' : `Extract ${zipCount} ZIP`}
-              </button>
+                {uploading ? 'Uploading...' : `Upload ${zipCount} ZIP`}
+              </Button>
             )}
 
             {imageCount > 0 && (
-              <button
+              <Button
+                type="button"
                 onClick={handleUpload}
                 disabled={uploading || imageCount === 0}
-                className="flex-1 flex items-center justify-center gap-2 bg-gradient-to-r from-blue-500 to-indigo-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-blue-600 hover:to-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                className="flex-1 gap-2 bg-gradient-to-r from-blue-500 to-indigo-600 text-white hover:from-blue-600 hover:to-indigo-700"
               >
                 <Upload className="w-5 h-5" />
                 {uploading ? 'Uploading...' : `Upload ${imageCount} Images`}
-              </button>
+              </Button>
             )}
           </div>
+
+          {/* Upload Progress */}
+          {uploading && zipUploadProgress > 0 && (
+            <div className="space-y-1">
+              <div className="flex justify-between text-xs text-muted-foreground">
+                <span>Uploading...</span>
+                <span>{zipUploadProgress}%</span>
+              </div>
+              <Progress value={zipUploadProgress} className="h-2" />
+            </div>
+          )}
 
           {/* Success Message */}
           {successCount === files.length && files.length > 0 && (
@@ -810,14 +803,15 @@ export default function DatasetUploader() {
           </div>
 
           {/* Download Button */}
-          <button
+          <Button
+            type="button"
             onClick={handleUrlDownload}
             disabled={downloading || !projectName.trim() || !datasetUrl.trim()}
-            className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-purple-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            className="w-full gap-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white hover:from-purple-600 hover:to-purple-700"
           >
             <Download className="w-5 h-5" />
             {downloading ? 'Downloading & Extracting...' : 'Download & Extract Dataset'}
-          </button>
+          </Button>
         </TabsContent>
 
         {/* ========== Create Folder Tab ========== */}
@@ -883,14 +877,15 @@ export default function DatasetUploader() {
           )}
 
           {/* Create Button */}
-          <button
+          <Button
+            type="button"
             onClick={handleCreateFolder}
             disabled={creatingFolder || !folderName.trim()}
-            className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-green-500 to-green-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-green-600 hover:to-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            className="w-full gap-2 bg-gradient-to-r from-green-500 to-green-600 text-white hover:from-green-600 hover:to-green-700"
           >
             <FolderPlus className="w-5 h-5" />
             {creatingFolder ? 'Creating...' : 'Create Folder'}
-          </button>
+          </Button>
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/components/DatasetUploader.tsx
+++ b/frontend/components/DatasetUploader.tsx
@@ -298,18 +298,7 @@ export default function DatasetUploader() {
     const zipped = zipSync(zipData);
     const zipBlob = new Blob([zipped.buffer as ArrayBuffer], { type: 'application/zip' });
 
-<<<<<<< HEAD
     const result = await handleChunkedZipUpload(zipBlob, `${datasetName}.zip`, datasetName);
-=======
-    const formData = new FormData();
-    formData.append('file', new File([zipBlob], `${datasetName}.zip`, { type: 'application/zip' }));
-    formData.append('dataset_name', datasetName);
-
-    setZipUploadProgress(0);
-    const result = await xhrUpload(`${API_BASE}/dataset/upload-zip`, formData, setZipUploadProgress) as { success: boolean; extracted?: number };
-    setZipUploadProgress(0);
-
->>>>>>> origin/main
     if (!result.success) {
       throw new Error(`No files extracted from ZIP (got ${result.extracted || 0} files)`);
     }
@@ -328,14 +317,6 @@ export default function DatasetUploader() {
     if (zipFiles.length === 0) { toast.warning('No ZIP files selected'); return; }
     if (!datasetName.trim()) { toast.warning('Please enter a dataset name'); return; }
 
-<<<<<<< HEAD
-=======
-    if (!datasetName.trim()) {
-      toast.warning('Please enter a dataset name');
-      return;
-    }
-
->>>>>>> origin/main
     if (datasetExists) {
       if (!confirm(`Dataset "${datasetName}" already exists!\n\nZIP contents will be extracted to the existing dataset. Continue?`)) return;
     }
@@ -344,31 +325,14 @@ export default function DatasetUploader() {
     if (!zipFile || zipFile.size === 0) { toast.error('ZIP file is empty or not loaded yet'); return; }
 
     setUploading(true);
-<<<<<<< HEAD
     try {
       const result = await handleChunkedZipUpload(zipFile, zipFile.name, datasetName);
-=======
-    setZipUploadProgress(0);
-
-    try {
-      const formData = new FormData();
-      formData.append('file', zipFile);
-      formData.append('dataset_name', datasetName);
-
-      const result = await xhrUpload(`${API_BASE}/dataset/upload-zip`, formData, setZipUploadProgress) as { success: boolean; extracted?: number; errors?: string[] };
-      setZipUploadProgress(0);
-
->>>>>>> origin/main
       if (result.success) {
         toast.success(`ZIP uploaded! Extracted ${result.extracted} images`, {
           description: result.errors && result.errors.length > 0 ? `Errors: ${result.errors.join(', ')}` : undefined,
         });
         revokePreviewUrls(files);
         setFiles([]);
-<<<<<<< HEAD
-=======
-
->>>>>>> origin/main
         try {
           const data = await datasetAPI.list();
           setExistingDatasets((data.datasets || []).map(d => d.name));
@@ -379,10 +343,6 @@ export default function DatasetUploader() {
         throw new Error(`No files extracted from ZIP (got ${result.extracted || 0} files)`);
       }
     } catch (err) {
-<<<<<<< HEAD
-=======
-      if (err instanceof Error && err.name === 'AbortError') return;
->>>>>>> origin/main
       toast.error(`ZIP upload failed: ${err}`);
     } finally {
       setUploading(false);
@@ -415,34 +375,6 @@ export default function DatasetUploader() {
     setFiles([]);
     setUploading(false);
   };
-
-  // XHR-based upload with progress tracking
-  const xhrUpload = (url: string, formData: FormData, onProgress: (pct: number) => void): Promise<unknown> =>
-    new Promise((resolve, reject) => {
-      const xhr = new XMLHttpRequest();
-      xhr.open('POST', url);
-      xhr.timeout = 600000; // 10 minutes for large uploads
-      xhr.upload.onprogress = (e) => {
-        if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100));
-      };
-      xhr.onload = () => {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          try { resolve(JSON.parse(xhr.responseText)); } catch { reject(new Error('Invalid JSON response')); }
-        } else {
-          try {
-            const err = JSON.parse(xhr.responseText) as { detail?: string };
-            reject(new Error(err.detail || `Server error (${xhr.status})`));
-          } catch {
-            reject(new Error(`Server error (${xhr.status}): ${xhr.responseText.substring(0, 200)}`));
-          }
-        }
-      };
-      xhr.onerror = () => reject(new Error('Network error'));
-      xhr.ontimeout = () => reject(new Error('Upload timed out after 10 minutes'));
-      xhr.onabort = () => { const e = new Error('Upload cancelled'); e.name = 'AbortError'; reject(e); };
-      uploadControllerRef.current = { abort: () => xhr.abort() };
-      xhr.send(formData);
-    });
 
   // ========== URL/ZIP Download Handlers ==========
 
@@ -780,11 +712,7 @@ export default function DatasetUploader() {
                 className="flex-1 gap-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white hover:from-purple-600 hover:to-purple-700"
               >
                 <FileArchive className="w-5 h-5" />
-<<<<<<< HEAD
                 {uploading ? 'Uploading...' : `Upload ${zipCount} ZIP`}
-=======
-                {uploading ? 'Extracting...' : `Extract ${zipCount} ZIP`}
->>>>>>> origin/main
               </Button>
             )}
 

--- a/frontend/components/training/TrainingMonitor.tsx
+++ b/frontend/components/training/TrainingMonitor.tsx
@@ -181,13 +181,13 @@ export default function TrainingMonitor() {
             ...prev,
             progress: {
               ...prev.progress,
-              ...(data.step_num != null && { current_step: data.step_num }),
-              ...(data.total_steps != null && { total_steps: data.total_steps }),
-              ...(data.current_epoch != null && { current_epoch: data.current_epoch }),
-              ...(data.total_epochs != null && { total_epochs: data.total_epochs }),
-              ...(data.loss != null && { loss: data.loss }),
-              ...(data.lr != null && { lr: data.lr }),
-              ...(data.eta_seconds != null && { eta_seconds: data.eta_seconds }),
+              ...(data.step_num != null && { current_step: data.step_num as number }),
+              ...(data.total_steps != null && { total_steps: data.total_steps as number }),
+              ...(data.current_epoch != null && { current_epoch: data.current_epoch as number }),
+              ...(data.total_epochs != null && { total_epochs: data.total_epochs as number }),
+              ...(data.loss != null && { loss: data.loss as number }),
+              ...(data.lr != null && { lr: data.lr as number }),
+              ...(data.eta_seconds != null && { eta_seconds: data.eta_seconds as number }),
             },
           }));
         } else if (data.type === 'status') {

--- a/frontend/lib/node-services/config-service.ts
+++ b/frontend/lib/node-services/config-service.ts
@@ -46,7 +46,7 @@ interface TrainingConfig {
   optimizer_type: string;
   max_grad_norm: number;
   weight_decay: number;
-  optimizer_args?: string[];
+  optimizer_args?: string;
 
   // Network (LoRA) settings
   lora_type: string;


### PR DESCRIPTION
## Summary

Replaces the single-request fetch() ZIP upload paths with a three-step chunked protocol that survives connection drops on VastAI/RunPod flaky networks.

**New Next.js API routes:**
- POST /api/dataset/upload-chunk-init — opens a session, creates a temp scratch dir in os.tmpdir()
- POST /api/dataset/upload-chunk — receives one 10 MB slice and writes it to disk (keepalive: true for Cloudflared/Caddy tunnels)
- POST /api/dataset/upload-chunk-finalize — concatenates all parts in order, proxies the assembled ZIP to the existing FastAPI extraction endpoint, cleans up temp dir

**Frontend (DatasetUploader.tsx):**
- handleChunkedZipUpload(file, fileName, datasetName) — splits via File.slice(), uploads sequentially, retries each chunk up to 3x with 1.5s*attempt backoff
- Remote GPU mode (handleUploadZipped): builds in-memory ZIP with fflate, then chunks the Blob through the same path
- Direct ZIP drop (handleUploadZip): chunks the File directly, no in-memory build
- shadcn Progress bar shows percentage during upload
- All raw <button> elements converted to shadcn <Button> (CLAUDE.md compliance)

**Also fixes two pre-existing TypeScript errors:**
- TrainingMonitor.tsx: as number casts on step_progress spread (unknown index values)
- config-service.ts: optimizer_args typed as string[] but UI sends a space-separated string

No Socket.IO, no new npm dependencies. Works through Caddy/Cloudflared (plain HTTP chunks).

## Test plan

- [ ] Drop a large ZIP (>10 MB) -- progress bar fills in chunk increments, success toast fires
- [ ] Drop a ZIP <10 MB (single chunk) -- still works, progress jumps to 100%
- [ ] Drop images in Remote GPU mode -- fflate ZIP built in memory, chunked through same path
- [ ] Batch image upload (local mode) -- unchanged, no regression
- [ ] Simulate a slow connection -- retry logic fires on a failed chunk, upload eventually completes
- [ ] Navigate away mid-upload -- temp dir cleaned up by finalize finally block on next attempt

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chunked ZIP upload flow with init/upload/finalize endpoints and client-side chunking, retry/backoff, and assembled upload.
  * ZIP-from-images support (zips images in-browser before upload).

* **Improvements**
  * Updated uploader UI with modern buttons, progress bars, and ZIP-specific progress.
  * More accurate training progress metrics handling.
  * Configuration schema adjusted for optimizer arguments.

* **Bug Fixes**
  * Temporary upload scratch cleaned up reliably after finalize.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->