### PR TITLE
fix: resolve training log stream cutout after ~1000 lines (absolute cursor)

### DIFF
--- a/api/routes/training.py
+++ b/api/routes/training.py
@@ -401,7 +401,7 @@ async def get_training_logs(job_id: str, since: int = 0, limit: int = 0):
             "success": True,
             "job_id": job_id,
             "logs": formatted_logs,
-            "total_logs": len(job.logs),
+            "total_logs": job.total_lines_written,
             "status": job.status.value,
             "progress": job.progress,
             "step_num": job.step_num,
@@ -412,7 +412,7 @@ async def get_training_logs(job_id: str, since: int = 0, limit: int = 0):
             "lr": job.lr,
             "eta_seconds": job.eta_seconds,
             "error": job.error,
-            "next_since": since + len(logs),
+            "next_since": job.total_lines_written,
         }
 
     except HTTPException:

--- a/api/routes/training.py
+++ b/api/routes/training.py
@@ -397,6 +397,11 @@ async def get_training_logs(job_id: str, since: int = 0, limit: int = 0):
             for line in logs
         ]
 
+        # next_since must reflect the last line actually returned, not the tip —
+        # otherwise a limit-truncated response causes the client to skip buffered lines.
+        oldest_absolute = job.total_lines_written - len(job.logs)
+        next_since = max(since, oldest_absolute) + len(logs)
+
         return {
             "success": True,
             "job_id": job_id,
@@ -412,7 +417,7 @@ async def get_training_logs(job_id: str, since: int = 0, limit: int = 0):
             "lr": job.lr,
             "eta_seconds": job.eta_seconds,
             "error": job.error,
-            "next_since": job.total_lines_written,
+            "next_since": next_since,
         }
 
     except HTTPException:

--- a/frontend/app/api/dataset/upload-zip/route.ts
+++ b/frontend/app/api/dataset/upload-zip/route.ts
@@ -37,23 +37,30 @@ function backendBase(): string {
  */
 export async function POST(request: NextRequest) {
   try {
+    const contentType = request.headers.get('content-type');
+    if (!contentType) {
+      return NextResponse.json(
+        { error: 'Missing content-type header — multipart boundary required' },
+        { status: 400 }
+      );
+    }
+
+    const forwardHeaders: Record<string, string> = { 'content-type': contentType };
+    const contentLength = request.headers.get('content-length');
+    if (contentLength) forwardHeaders['content-length'] = contentLength;
+
     const res = await fetch(`${backendBase()}/api/dataset/upload-zip`, {
       method: 'POST',
       // Stream directly — do NOT await request.formData() which buffers the
       // entire body into memory before forwarding, causing timeouts on large ZIPs.
       body: request.body,
-      headers: {
-        'content-type': request.headers.get('content-type') ?? '',
-        ...(request.headers.get('content-length')
-          ? { 'content-length': request.headers.get('content-length')! }
-          : {}),
-      },
+      headers: forwardHeaders,
       // Required by Node.js fetch to allow a streaming request body.
       // @ts-expect-error duplex is a valid Node.js fetch option not yet in the TypeScript types
       duplex: 'half',
     });
 
-    const contentType = res.headers.get('content-type') || '';
+    const resContentType = res.headers.get('content-type') || '';
 
     if (!res.ok) {
       const errText = await res.text();
@@ -63,7 +70,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (contentType.includes('application/json')) {
+    if (resContentType.includes('application/json')) {
       return NextResponse.json(await res.json(), { status: res.status });
     }
 

--- a/frontend/app/api/dataset/upload-zip/route.ts
+++ b/frontend/app/api/dataset/upload-zip/route.ts
@@ -7,6 +7,10 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 
+// Large ZIP uploads can take several minutes — prevent the default timeout from
+// killing the request mid-stream.
+export const maxDuration = 300;
+
 /**
  * Determine the base URL for the backend service.
  *
@@ -24,15 +28,29 @@ function backendBase(): string {
 /**
  * Proxies multipart ZIP upload requests to the backend's /api/dataset/upload-zip endpoint and returns the backend response.
  *
+ * Streams the request body directly to FastAPI without buffering it in Node.js
+ * memory — avoids ECONNRESET on large files caused by buffering the entire
+ * multipart body before forwarding.
+ *
  * @param request - Incoming Next.js request containing multipart form data (the uploaded ZIP)
  * @returns A NextResponse containing the backend's JSON response (status mirrors the backend). If the backend returns non-OK, returns a JSON error with the backend status and truncated detail; if a proxy error occurs, returns a JSON error with status 500.
  */
 export async function POST(request: NextRequest) {
   try {
-    const formData = await request.formData();
     const res = await fetch(`${backendBase()}/api/dataset/upload-zip`, {
       method: 'POST',
-      body: formData,
+      // Stream directly — do NOT await request.formData() which buffers the
+      // entire body into memory before forwarding, causing timeouts on large ZIPs.
+      body: request.body,
+      headers: {
+        'content-type': request.headers.get('content-type') ?? '',
+        ...(request.headers.get('content-length')
+          ? { 'content-length': request.headers.get('content-length')! }
+          : {}),
+      },
+      // Required by Node.js fetch to allow a streaming request body.
+      // @ts-expect-error duplex is a valid Node.js fetch option not yet in the TypeScript types
+      duplex: 'half',
     });
 
     const contentType = res.headers.get('content-type') || '';

--- a/services/jobs/job.py
+++ b/services/jobs/job.py
@@ -42,8 +42,8 @@ class Job:
     total_images: Optional[int] = None
 
     # Log buffer (keep last max_logs lines)
-    logs: deque = field(default_factory=lambda: deque(maxlen=2000))
     max_logs: int = 2000
+    logs: deque = field(init=False)
     # Absolute count of lines ever written — survives deque eviction.
     # 'since' cursors from the frontend are absolute offsets into this counter,
     # not relative indices into the deque. This prevents the deque wrap-around
@@ -53,6 +53,9 @@ class Job:
     # Error tracking
     error: Optional[str] = None
     error_traceback: Optional[str] = None
+
+    def __post_init__(self):
+        self.logs = deque(maxlen=self.max_logs)
 
     def add_log(self, log_line: str):
         """Add log line to buffer"""

--- a/services/jobs/job.py
+++ b/services/jobs/job.py
@@ -55,6 +55,7 @@ class Job:
     error_traceback: Optional[str] = None
 
     def __post_init__(self):
+        """Initialise the log deque with the configured max_logs capacity."""
         self.logs = deque(maxlen=self.max_logs)
 
     def add_log(self, log_line: str):

--- a/services/jobs/job.py
+++ b/services/jobs/job.py
@@ -42,8 +42,13 @@ class Job:
     total_images: Optional[int] = None
 
     # Log buffer (keep last max_logs lines)
-    logs: deque = field(default_factory=lambda: deque(maxlen=1000))
-    max_logs: int = 1000
+    logs: deque = field(default_factory=lambda: deque(maxlen=2000))
+    max_logs: int = 2000
+    # Absolute count of lines ever written — survives deque eviction.
+    # 'since' cursors from the frontend are absolute offsets into this counter,
+    # not relative indices into the deque. This prevents the deque wrap-around
+    # bug where get_logs(N) returns [] forever once N == maxlen.
+    total_lines_written: int = 0
 
     # Error tracking
     error: Optional[str] = None
@@ -52,20 +57,28 @@ class Job:
     def add_log(self, log_line: str):
         """Add log line to buffer"""
         self.logs.append(log_line)
+        self.total_lines_written += 1
 
-    def get_logs(self, start: int = 0) -> list[str]:
+    def get_logs(self, since: int = 0) -> list[str]:
         """
-        Get logs starting from line number.
+        Get logs since an absolute line number.
 
         Args:
-            start: Line number to start from (0-indexed)
+            since: Absolute line count offset (matches total_lines_written
+                   at the time the caller last received logs). NOT a deque index.
 
         Returns:
-            List of log lines from start onwards
+            List of log lines from since onwards (capped to buffered window).
         """
-        if start >= len(self.logs):
+        # Oldest absolute line number still in the deque
+        oldest_absolute = self.total_lines_written - len(self.logs)
+        if since <= oldest_absolute:
+            # Caller is behind the buffer window — return everything buffered
+            return list(self.logs)
+        relative_start = since - oldest_absolute
+        if relative_start >= len(self.logs):
             return []
-        return list(self.logs)[start:]
+        return list(self.logs)[relative_start:]
 
     @property
     def is_running(self) -> bool:

--- a/services/jobs/job_manager.py
+++ b/services/jobs/job_manager.py
@@ -277,7 +277,7 @@ class JobManager:
             yield log_line
 
         # Then stream new logs as they arrive
-        last_line = len(job.logs)
+        last_line = job.total_lines_written
         heartbeat_counter = 0
 
         while not job.is_complete:
@@ -294,7 +294,7 @@ class JobManager:
             for log_line in new_logs:
                 yield log_line
 
-            last_line = len(job.logs)
+            last_line = job.total_lines_written
 
         # Send final logs after completion
         final_logs = job.get_logs(last_line)

--- a/tests/test_job_log_cursor.py
+++ b/tests/test_job_log_cursor.py
@@ -26,22 +26,27 @@ class TestGetLogsBeforeEviction:
     """Buffer not yet full — no eviction, simple indexing."""
 
     def test_get_all_from_zero(self):
+        """since=0 returns every line when buffer is not yet full."""
         j = make_job(100, maxlen=200)
         assert j.get_logs(0) == [f"line {i}" for i in range(100)]
 
     def test_get_from_middle(self):
+        """since=50 returns only the second half of 100 lines."""
         j = make_job(100, maxlen=200)
         assert j.get_logs(50) == [f"line {i}" for i in range(50, 100)]
 
     def test_get_at_tip_returns_empty(self):
+        """since equal to total_lines_written returns an empty list."""
         j = make_job(100, maxlen=200)
         assert j.get_logs(100) == []
 
     def test_get_past_tip_returns_empty(self):
+        """since beyond total_lines_written returns an empty list."""
         j = make_job(100, maxlen=200)
         assert j.get_logs(200) == []
 
     def test_total_lines_written_tracks_count(self):
+        """total_lines_written equals the number of lines added."""
         j = make_job(100, maxlen=200)
         assert j.total_lines_written == 100
 
@@ -50,6 +55,7 @@ class TestGetLogsAfterEviction:
     """Buffer full — oldest entries evicted; absolute cursor must still work."""
 
     def test_cursor_at_zero_returns_all_buffered(self):
+        """since=0 with evicted lines returns all 200 buffered entries starting at oldest."""
         # 500 lines into a 200-entry buffer → first 300 evicted
         j = make_job(500, maxlen=200)
         result = j.get_logs(0)
@@ -57,6 +63,7 @@ class TestGetLogsAfterEviction:
         assert result[0] == "line 300"   # oldest still buffered
 
     def test_cursor_behind_oldest_returns_all_buffered(self):
+        """since inside the evicted window falls back to returning all buffered entries."""
         j = make_job(500, maxlen=200)
         # since=299 is still inside the evicted window → return all buffered
         result = j.get_logs(299)
@@ -64,12 +71,14 @@ class TestGetLogsAfterEviction:
         assert result[0] == "line 300"
 
     def test_cursor_at_oldest_returns_all_buffered(self):
+        """since exactly at oldest_absolute returns all buffered entries."""
         j = make_job(500, maxlen=200)
         # since=300 is exactly at oldest_absolute → return all buffered
         result = j.get_logs(300)
         assert len(result) == 200
 
     def test_cursor_inside_buffer(self):
+        """since inside the retained window returns only lines from that point forward."""
         j = make_job(500, maxlen=200)
         # since=400 → oldest_absolute=300, relative=100, should return last 100
         result = j.get_logs(400)
@@ -78,14 +87,17 @@ class TestGetLogsAfterEviction:
         assert result[-1] == "line 499"
 
     def test_cursor_at_tip_returns_empty(self):
+        """since equal to total_lines_written returns empty after eviction."""
         j = make_job(500, maxlen=200)
         assert j.get_logs(500) == []
 
     def test_cursor_past_tip_returns_empty(self):
+        """since beyond total_lines_written returns empty after eviction."""
         j = make_job(500, maxlen=200)
         assert j.get_logs(999) == []
 
     def test_total_lines_written_past_maxlen(self):
+        """total_lines_written keeps counting past the deque maxlen."""
         j = make_job(500, maxlen=200)
         assert j.total_lines_written == 500
         assert len(j.logs) == 200

--- a/tests/test_job_log_cursor.py
+++ b/tests/test_job_log_cursor.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for Job.get_logs absolute cursor behaviour.
+
+Regression tests for the deque wrap-around bug where get_logs(N) returned []
+forever once N reached the deque maxlen — causing the log stream to silently
+cut out after ~1000 lines (~5-7 min on a 4090).
+"""
+import pytest
+from services.jobs.job import Job
+from services.models.job import JobType
+
+
+def make_job(n_lines: int, maxlen: int = 2000) -> Job:
+    """Create a job and write n_lines log entries into it."""
+    j = Job(job_id="test", job_type=JobType.TRAINING)
+    j.logs.maxlen  # confirm deque is initialised
+    # Override maxlen for testing small cases without 2000-entry loops
+    from collections import deque
+    j.logs = deque(maxlen=maxlen)
+    j.total_lines_written = 0
+    for i in range(n_lines):
+        j.add_log(f"line {i}")
+    return j
+
+
+class TestGetLogsBeforeEviction:
+    """Buffer not yet full — no eviction, simple indexing."""
+
+    def test_get_all_from_zero(self):
+        j = make_job(100, maxlen=200)
+        assert j.get_logs(0) == [f"line {i}" for i in range(100)]
+
+    def test_get_from_middle(self):
+        j = make_job(100, maxlen=200)
+        assert j.get_logs(50) == [f"line {i}" for i in range(50, 100)]
+
+    def test_get_at_tip_returns_empty(self):
+        j = make_job(100, maxlen=200)
+        assert j.get_logs(100) == []
+
+    def test_get_past_tip_returns_empty(self):
+        j = make_job(100, maxlen=200)
+        assert j.get_logs(200) == []
+
+    def test_total_lines_written_tracks_count(self):
+        j = make_job(100, maxlen=200)
+        assert j.total_lines_written == 100
+
+
+class TestGetLogsAfterEviction:
+    """Buffer full — oldest entries evicted; absolute cursor must still work."""
+
+    def test_cursor_at_zero_returns_all_buffered(self):
+        # 500 lines into a 200-entry buffer → first 300 evicted
+        j = make_job(500, maxlen=200)
+        result = j.get_logs(0)
+        assert len(result) == 200
+        assert result[0] == "line 300"   # oldest still buffered
+
+    def test_cursor_behind_oldest_returns_all_buffered(self):
+        j = make_job(500, maxlen=200)
+        # since=299 is still inside the evicted window → return all buffered
+        result = j.get_logs(299)
+        assert len(result) == 200
+        assert result[0] == "line 300"
+
+    def test_cursor_at_oldest_returns_all_buffered(self):
+        j = make_job(500, maxlen=200)
+        # since=300 is exactly at oldest_absolute → return all buffered
+        result = j.get_logs(300)
+        assert len(result) == 200
+
+    def test_cursor_inside_buffer(self):
+        j = make_job(500, maxlen=200)
+        # since=400 → oldest_absolute=300, relative=100, should return last 100
+        result = j.get_logs(400)
+        assert len(result) == 100
+        assert result[0] == "line 400"
+        assert result[-1] == "line 499"
+
+    def test_cursor_at_tip_returns_empty(self):
+        j = make_job(500, maxlen=200)
+        assert j.get_logs(500) == []
+
+    def test_cursor_past_tip_returns_empty(self):
+        j = make_job(500, maxlen=200)
+        assert j.get_logs(999) == []
+
+    def test_total_lines_written_past_maxlen(self):
+        j = make_job(500, maxlen=200)
+        assert j.total_lines_written == 500
+        assert len(j.logs) == 200
+
+    def test_regression_next_since_never_stalls(self):
+        """
+        Simulate the polling loop that caused the original cutout.
+        With the old code, next_since would reach maxlen and get stuck.
+        With the fix, next_since advances past maxlen via total_lines_written.
+        """
+        j = make_job(0, maxlen=10)
+        next_since = 0
+
+        for i in range(25):
+            j.add_log(f"line {i}")
+            new_logs = j.get_logs(next_since)
+            next_since = j.total_lines_written
+            # There should always be exactly 1 new log per iteration
+            assert len(new_logs) == 1, (
+                f"iteration {i}: expected 1 new log, got {len(new_logs)} "
+                f"(next_since was {next_since - 1}, total={j.total_lines_written})"
+            )
+
+        assert next_since == 25

--- a/tests/test_job_log_cursor.py
+++ b/tests/test_job_log_cursor.py
@@ -13,7 +13,6 @@ from services.models.job import JobType
 def make_job(n_lines: int, maxlen: int = 2000) -> Job:
     """Create a job and write n_lines log entries into it."""
     j = Job(job_id="test", job_type=JobType.TRAINING)
-    j.logs.maxlen  # confirm deque is initialised
     # Override maxlen for testing small cases without 2000-entry loops
     from collections import deque
     j.logs = deque(maxlen=maxlen)


### PR DESCRIPTION
## Summary

- Replaces `deque`-relative buffer index with an absolute `total_lines_written` counter in the log polling backend, fixing a silent stall that cut off log output after ~1000 lines
- Adds regression tests for `Job.get_logs` covering the absolute cursor behaviour to prevent recurrence

## Why this happened

`deque(maxlen=N)` silently discards old entries when full. A buffer-relative cursor index that reached the end of the deque would never advance further, causing the SSE log stream to stop delivering new lines even as training continued.

## Test plan

- [x] Regression tests added (`e56f661`) covering the absolute cursor path
- [ ] Manual smoke test: start a long training run (>1000 log lines) and confirm log stream keeps scrolling
- [ ] Confirm no log duplication on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable log pagination and streaming by switching to an absolute line-count cursor so log cursors advance correctly when older entries are evicted.

* **Tests**
  * Added comprehensive tests covering log cursor behavior across buffer states and edge-case polling.

* **New Features**
  * Improved large ZIP upload handling in the frontend API: streaming proxy support and extended request duration to prevent mid-upload timeouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ktiseos-Nyx/Ktiseos-Nyx-Trainer/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->